### PR TITLE
Updated Protos, includes ServerRankRevealAll

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ endif
 
 default: demoinfogo
 
-demoinfogo: src/demofile.o src/demofiledump.o src/demoinfogo.o src/demofilebitbuf.o src/demofilepropdecode.o src/generated_proto/netmessages_public.pb.cc src/generated_proto/cstrike15_usermessages_public.pb.cc
+demoinfogo: src/demofile.o src/demofiledump.o src/demoinfogo.o src/demofilebitbuf.o src/demofilepropdecode.o src/generated_proto/steammessages.pb.cc src/generated_proto/cstrike15_gcmessages.pb.cc src/generated_proto/netmessages_public.pb.cc src/generated_proto/cstrike15_usermessages_public.pb.cc
 	$(CC) $(INC) $^ $(PROTOBUF_LIB) $(LDFLAGS) -o $@
 
 src/demofile.o: src/demofile.cpp
 	$(CC) $(CFLAGS) $(INC) -c $< -o $@
 
-src/demofiledump.o: src/demofiledump.cpp src/generated_proto/netmessages_public.pb.cc src/generated_proto/cstrike15_usermessages_public.pb.cc
+src/demofiledump.o: src/demofiledump.cpp src/generated_proto/steammessages.pb.cc src/generated_proto/cstrike15_gcmessages.pb.cc src/generated_proto/netmessages_public.pb.cc src/generated_proto/cstrike15_usermessages_public.pb.cc
 	$(CC) $(CFLAGS) $(INC) -c $< -o $@
 
 src/demoinfogo.o: src/demoinfogo.cpp
@@ -34,6 +34,14 @@ src/demofilebitbuf.o: src/demofilebitbuf.cpp
 
 src/demofilepropdecode.o: src/demofilepropdecode.cpp
 	$(CC) $(CFLAGS) $(INC) -c $< -o $@
+
+src/generated_proto/steammessages.pb.cc: src/steammessages.proto
+	mkdir -p src/generated_proto
+	$(PROTOBUF_SRC)/protoc --proto_path=./src --proto_path=$(PROTOBUF_SRC) --cpp_out=./src/generated_proto $<
+
+src/generated_proto/cstrike15_gcmessages.pb.cc: src/cstrike15_gcmessages.proto
+	mkdir -p src/generated_proto
+	$(PROTOBUF_SRC)/protoc --proto_path=./src --proto_path=$(PROTOBUF_SRC) --cpp_out=./src/generated_proto $<
 
 src/generated_proto/netmessages_public.pb.cc: src/netmessages_public.proto
 	mkdir -p src/generated_proto

--- a/src/cstrike15_gcmessages.proto
+++ b/src/cstrike15_gcmessages.proto
@@ -1,0 +1,945 @@
+import "steammessages.proto";
+
+option optimize_for = SPEED;
+option cc_generic_services = false;
+
+enum ECsgoGCMsg {
+	k_EMsgGCCStrike15_v2_Base = 9100;
+	k_EMsgGCCStrike15_v2_MatchmakingStart = 9101;
+	k_EMsgGCCStrike15_v2_MatchmakingStop = 9102;
+	k_EMsgGCCStrike15_v2_MatchmakingClient2ServerPing = 9103;
+	k_EMsgGCCStrike15_v2_MatchmakingGC2ClientUpdate = 9104;
+	k_EMsgGCCStrike15_v2_MatchmakingGC2ServerReserve = 9105;
+	k_EMsgGCCStrike15_v2_MatchmakingServerReservationResponse = 9106;
+	k_EMsgGCCStrike15_v2_MatchmakingGC2ClientReserve = 9107;
+	k_EMsgGCCStrike15_v2_MatchmakingServerRoundStats = 9108;
+	k_EMsgGCCStrike15_v2_MatchmakingClient2GCHello = 9109;
+	k_EMsgGCCStrike15_v2_MatchmakingGC2ClientHello = 9110;
+	k_EMsgGCCStrike15_v2_MatchmakingServerMatchEnd = 9111;
+	k_EMsgGCCStrike15_v2_MatchmakingGC2ClientAbandon = 9112;
+	k_EMsgGCCStrike15_v2_MatchmakingServer2GCKick = 9113;
+	k_EMsgGCCStrike15_v2_MatchmakingGC2ServerConfirm = 9114;
+	k_EMsgGCCStrike15_v2_MatchmakingGCOperationalStats = 9115;
+	k_EMsgGCCStrike15_v2_MatchmakingGC2ServerRankUpdate = 9116;
+	k_EMsgGCCStrike15_v2_MatchmakingOperator2GCBlogUpdate = 9117;
+	k_EMsgGCCStrike15_v2_ServerNotificationForUserPenalty = 9118;
+	k_EMsgGCCStrike15_v2_ClientReportPlayer = 9119;
+	k_EMsgGCCStrike15_v2_ClientReportServer = 9120;
+	k_EMsgGCCStrike15_v2_ClientCommendPlayer = 9121;
+	k_EMsgGCCStrike15_v2_ClientReportResponse = 9122;
+	k_EMsgGCCStrike15_v2_ClientCommendPlayerQuery = 9123;
+	k_EMsgGCCStrike15_v2_ClientCommendPlayerQueryResponse = 9124;
+	k_EMsgGCCStrike15_v2_WatchInfoUsers = 9126;
+	k_EMsgGCCStrike15_v2_ClientRequestPlayersProfile = 9127;
+	k_EMsgGCCStrike15_v2_PlayersProfile = 9128;
+	k_EMsgGCCStrike15_v2_SetMyMedalsInfo = 9129;
+	k_EMsgGCCStrike15_v2_PlayerOverwatchCaseUpdate = 9131;
+	k_EMsgGCCStrike15_v2_PlayerOverwatchCaseAssignment = 9132;
+	k_EMsgGCCStrike15_v2_PlayerOverwatchCaseStatus = 9133;
+	k_EMsgGCCStrike15_v2_GC2ClientTextMsg = 9134;
+	k_EMsgGCCStrike15_v2_Client2GCTextMsg = 9135;
+	k_EMsgGCCStrike15_v2_MatchEndRunRewardDrops = 9136;
+	k_EMsgGCCStrike15_v2_MatchEndRewardDropsNotification = 9137;
+	k_EMsgGCCStrike15_v2_ClientRequestWatchInfoFriends2 = 9138;
+	k_EMsgGCCStrike15_v2_MatchList = 9139;
+	k_EMsgGCCStrike15_v2_MatchListRequestCurrentLiveGames = 9140;
+	k_EMsgGCCStrike15_v2_MatchListRequestRecentUserGames = 9141;
+	k_EMsgGCCStrike15_v2_GC2ServerReservationUpdate = 9142;
+	k_EMsgGCCStrike15_v2_ClientVarValueNotificationInfo = 9144;
+	k_EMsgGCCStrike15_v2_TournamentMatchRewardDropsNotification = 9145;
+	k_EMsgGCCStrike15_v2_MatchListRequestTournamentGames = 9146;
+	k_EMsgGCCStrike15_v2_MatchListRequestFullGameInfo = 9147;
+	k_EMsgGCCStrike15_v2_GiftsLeaderboardRequest = 9148;
+	k_EMsgGCCStrike15_v2_GiftsLeaderboardResponse = 9149;
+	k_EMsgGCCStrike15_v2_ServerVarValueNotificationInfo = 9150;
+	k_EMsgGCToGCReloadVersions = 9151;
+	k_EMsgGCCStrike15_v2_ClientSubmitSurveyVote = 9152;
+	k_EMsgGCCStrike15_v2_Server2GCClientValidate = 9153;
+	k_EMsgGCCStrike15_v2_MatchListRequestLiveGameForUser = 9154;
+	k_EMsgGCCStrike15_v2_Server2GCPureServerValidationFailure = 9155;
+	k_EMsgGCCStrike15_v2_Client2GCEconPreviewDataBlockRequest = 9156;
+	k_EMsgGCCStrike15_v2_Client2GCEconPreviewDataBlockResponse = 9157;
+	k_EMsgGCCStrike15_v2_AccountPrivacySettings = 9158;
+	k_EMsgGCCStrike15_v2_SetMyActivityInfo = 9159;
+	k_EMsgGCCStrike15_v2_MatchListRequestTournamentPredictions = 9160;
+	k_EMsgGCCStrike15_v2_MatchListUploadTournamentPredictions = 9161;
+	k_EMsgGCCStrike15_v2_DraftSummary = 9162;
+	k_EMsgGCCStrike15_v2_ClientRequestJoinFriendData = 9163;
+	k_EMsgGCCStrike15_v2_ClientRequestJoinServerData = 9164;
+	k_EMsgGCCStrike15_v2_ClientRequestNewMission = 9165;
+	k_EMsgGCCStrike15_v2_GC2ServerNotifyXPRewarded = 9166;
+	k_EMsgGCCStrike15_v2_GC2ClientTournamentInfo = 9167;
+	k_EMsgGC_GlobalGame_Subscribe = 9168;
+	k_EMsgGC_GlobalGame_Unsubscribe = 9169;
+	k_EMsgGC_GlobalGame_Play = 9170;
+	k_EMsgGCCStrike15_v2_AcknowledgePenalty = 9171;
+	k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin = 9172;
+	k_EMsgGCCStrike15_v2_GC2ClientGlobalStats = 9173;
+	k_EMsgGCCStrike15_v2_Client2GCStreamUnlock = 9174;
+	k_EMsgGCCStrike15_v2_FantasyRequestClientData = 9175;
+	k_EMsgGCCStrike15_v2_FantasyUpdateClientData = 9176;
+}
+
+message GameServerPing {
+	optional uint64 gameserver_id = 1;
+	optional int32 ping = 2;
+	optional uint32 ip = 3;
+	optional uint32 port = 4;
+	optional uint32 instances = 5;
+}
+
+message DetailedSearchStatistic {
+	optional uint32 game_type = 1;
+	optional uint32 search_time_avg = 2;
+	optional uint32 players_searching = 4;
+}
+
+message TournamentPlayer {
+	optional uint32 account_id = 1;
+	optional string player_nick = 2;
+	optional string player_name = 3;
+	optional uint32 player_dob = 4;
+	optional string player_flag = 5;
+	optional string player_location = 6;
+	optional string player_desc = 7;
+}
+
+message TournamentTeam {
+	optional int32 team_id = 1;
+	optional string team_tag = 2;
+	optional string team_flag = 3;
+	optional string team_name = 4;
+	repeated .TournamentPlayer players = 5;
+}
+
+message TournamentEvent {
+	optional int32 event_id = 1;
+	optional string event_tag = 2;
+	optional string event_name = 3;
+	optional uint32 event_time_start = 4;
+	optional uint32 event_time_end = 5;
+	optional int32 event_public = 6;
+	optional int32 event_stage_id = 7;
+	optional string event_stage_name = 8;
+	optional uint32 active_section_id = 9;
+}
+
+message GlobalStatistics {
+	optional uint32 players_online = 1;
+	optional uint32 servers_online = 2;
+	optional uint32 players_searching = 3;
+	optional uint32 servers_available = 4;
+	optional uint32 ongoing_matches = 5;
+	optional uint32 search_time_avg = 6;
+	repeated .DetailedSearchStatistic search_statistics = 7;
+	optional string main_post_url = 8;
+	optional uint32 required_appid_version = 9;
+	optional uint32 pricesheet_version = 10;
+	optional uint32 twitch_streams_version = 11;
+	optional uint32 active_tournament_eventid = 12;
+	optional uint32 active_survey_id = 13;
+}
+
+message OperationalStatisticDescription {
+	optional string name = 1;
+	optional uint32 idkey = 2;
+}
+
+message OperationalStatisticElement {
+	optional uint32 idkey = 1;
+	repeated int32 values = 2;
+}
+
+message OperationalStatisticsPacket {
+	optional int32 packetid = 1;
+	optional int32 mstimestamp = 2;
+	repeated .OperationalStatisticElement values = 3;
+}
+
+message PlayerRankingInfo {
+	optional uint32 account_id = 1;
+	optional uint32 rank_id = 2;
+	optional uint32 wins = 3;
+	optional float rank_change = 4;
+}
+
+message PlayerCommendationInfo {
+	optional uint32 cmd_friendly = 1;
+	optional uint32 cmd_teaching = 2;
+	optional uint32 cmd_leader = 4;
+}
+
+message PlayerMedalsInfo {
+	optional uint32 medal_team = 1;
+	optional uint32 medal_combat = 2;
+	optional uint32 medal_weapon = 3;
+	optional uint32 medal_global = 4;
+	optional uint32 medal_arms = 5;
+	repeated uint32 display_items_defidx = 7;
+	optional uint32 featured_display_item_defidx = 8;
+}
+
+message AccountActivity {
+	optional uint32 activity = 1;
+	optional uint32 mode = 2;
+	optional uint32 map = 3;
+}
+
+message TournamentMatchSetup {
+	optional int32 event_id = 1;
+	optional int32 team_id_ct = 2;
+	optional int32 team_id_t = 3;
+	optional int32 event_stage_id = 4;
+}
+
+message ServerHltvInfo {
+	optional uint32 tv_udp_port = 1;
+	optional uint64 tv_watch_key = 2;
+	optional uint32 tv_slots = 3;
+	optional uint32 tv_clients = 4;
+	optional uint32 tv_proxies = 5;
+	optional uint32 tv_time = 6;
+	optional uint32 game_type = 8;
+	optional string game_mapgroup = 9;
+	optional string game_map = 10;
+	optional uint64 tv_master_steamid = 11;
+	optional uint32 tv_local_slots = 12;
+	optional uint32 tv_local_clients = 13;
+	optional uint32 tv_local_proxies = 14;
+	optional uint32 tv_relay_slots = 15;
+	optional uint32 tv_relay_clients = 16;
+	optional uint32 tv_relay_proxies = 17;
+	optional uint32 tv_relay_address = 18;
+	optional uint32 tv_relay_port = 19;
+	optional uint64 tv_relay_steamid = 20;
+}
+
+message IpAddressMask {
+	optional uint32 a = 1;
+	optional uint32 b = 2;
+	optional uint32 c = 3;
+	optional uint32 d = 4;
+	optional uint32 bits = 5;
+	optional uint32 token = 6;
+}
+
+message XpProgressData {
+	optional uint32 xp_points = 1;
+	optional int32 xp_category = 2;
+}
+
+message MatchEndItemUpdates {
+	optional uint64 item_id = 1;
+	optional uint32 item_attr_defidx = 2;
+	optional uint32 item_attr_delta_value = 3;
+}
+
+message ScoreLeaderboardData {
+	message Entry {
+		optional uint32 tag = 1;
+		optional uint32 val = 2;
+	}
+
+	message AccountEntries {
+		optional uint32 accountid = 1;
+		repeated .ScoreLeaderboardData.Entry entries = 2;
+	}
+
+	optional uint64 quest_id = 1;
+	optional uint32 score = 2;
+	repeated .ScoreLeaderboardData.AccountEntries accountentries = 3;
+	repeated .ScoreLeaderboardData.Entry matchentries = 5;
+}
+
+message PlayerQuestData {
+	message QuestItemData {
+		optional uint64 quest_id = 1;
+		optional int32 quest_normal_points_earned = 2;
+		optional int32 quest_bonus_points_earned = 3;
+	}
+
+	optional uint32 quester_account_id = 1;
+	repeated .PlayerQuestData.QuestItemData quest_item_data = 2;
+	repeated .XpProgressData xp_progress_data = 3;
+	optional uint32 time_played = 4;
+	optional uint32 mm_game_mode = 5;
+	repeated .MatchEndItemUpdates item_updates = 6;
+}
+
+message CMsgGC_ServerQuestUpdateData {
+	repeated .PlayerQuestData player_quest_data = 1;
+	optional bytes binary_data = 2;
+	optional uint32 mm_game_mode = 3;
+	optional .ScoreLeaderboardData missionlbsdata = 4;
+}
+
+message CMsgGCCStrike15_v2_MatchmakingGCOperationalStats {
+	optional int32 packetid = 1;
+	repeated .OperationalStatisticDescription namekeys = 2;
+	repeated .OperationalStatisticsPacket packets = 3;
+}
+
+message CMsgGCCStrike15_v2_MatchmakingGC2ServerConfirm {
+	optional uint32 token = 1;
+	optional uint32 stamp = 2;
+	optional uint64 exchange = 3;
+}
+
+message CMsgGCCStrike15_v2_GC2ServerReservationUpdate {
+	optional uint32 viewers_external_total = 1;
+	optional uint32 viewers_external_steam = 2;
+}
+
+message CMsgGCCStrike15_v2_MatchmakingStart {
+	repeated uint32 account_ids = 1;
+	optional uint32 game_type = 2;
+	optional string ticket_data = 3;
+	optional uint32 client_version = 4;
+	optional .TournamentMatchSetup tournament_match = 5;
+}
+
+message CMsgGCCStrike15_v2_MatchmakingStop {
+	optional int32 abandon = 1;
+}
+
+message CMsgGCCStrike15_v2_MatchmakingClient2ServerPing {
+	repeated .GameServerPing gameserverpings = 1;
+	optional int32 offset_index = 2;
+	optional int32 final_batch = 3;
+}
+
+message CMsgGCCStrike15_v2_MatchmakingGC2ClientUpdate {
+	message Note {
+		optional int32 type = 1;
+		optional int32 region_id = 2;
+		optional float region_r = 3;
+		optional float distance = 4;
+	}
+
+	optional int32 matchmaking = 1;
+	repeated uint32 waiting_account_id_sessions = 2;
+	optional string error = 3;
+	repeated uint32 ongoingmatch_account_id_sessions = 6;
+	optional .GlobalStatistics global_stats = 7;
+	repeated uint32 failping_account_id_sessions = 8;
+	repeated uint32 penalty_account_id_sessions = 9;
+	repeated uint32 failready_account_id_sessions = 10;
+	repeated uint32 vacbanned_account_id_sessions = 11;
+	optional .IpAddressMask server_ipaddress_mask = 12;
+	repeated .CMsgGCCStrike15_v2_MatchmakingGC2ClientUpdate.Note notes = 13;
+	repeated uint32 penalty_account_id_sessions_green = 14;
+	repeated uint32 insufficientlevel_sessions = 15;
+}
+
+message CDataGCCStrike15_v2_TournamentMatchDraft {
+	message Entry {
+		optional int32 mapid = 1;
+		optional int32 team_id_ct = 2;
+	}
+
+	optional int32 event_id = 1;
+	optional int32 event_stage_id = 2;
+	optional int32 team_id_0 = 3;
+	optional int32 team_id_1 = 4;
+	optional int32 maps_count = 5;
+	optional int32 maps_current = 6;
+	optional int32 team_id_start = 7;
+	optional int32 team_id_veto1 = 8;
+	optional int32 team_id_pickn = 9;
+	repeated .CDataGCCStrike15_v2_TournamentMatchDraft.Entry drafts = 10;
+}
+
+message CPreMatchInfoData {
+	message TeamStats {
+		optional int32 match_info_idxtxt = 1;
+		optional string match_info_txt = 2;
+		repeated string match_info_teams = 3;
+	}
+
+	optional int32 predictions_pct = 1;
+	optional .CDataGCCStrike15_v2_TournamentMatchDraft draft = 4;
+	repeated .CPreMatchInfoData.TeamStats stats = 5;
+}
+
+message CMsgGCCStrike15_v2_MatchmakingGC2ServerReserve {
+	repeated uint32 account_ids = 1;
+	optional uint32 game_type = 2;
+	optional uint64 match_id = 3;
+	optional uint32 server_version = 4;
+	repeated .PlayerRankingInfo rankings = 5;
+	optional uint64 encryption_key = 6;
+	optional uint64 encryption_key_pub = 7;
+	repeated uint32 party_ids = 8;
+	repeated .IpAddressMask whitelist = 9;
+	optional uint64 tv_master_steamid = 10;
+	optional .TournamentEvent tournament_event = 11;
+	repeated .TournamentTeam tournament_teams = 12;
+	repeated uint32 tournament_casters_account_ids = 13;
+	optional uint64 tv_relay_steamid = 14;
+	optional .CPreMatchInfoData pre_match_data = 15;
+}
+
+message CMsgGCCStrike15_v2_MatchmakingServerReservationResponse {
+	optional uint64 reservationid = 1;
+	optional .CMsgGCCStrike15_v2_MatchmakingGC2ServerReserve reservation = 2;
+	optional string map = 3;
+	optional uint64 gc_reservation_sent = 4;
+	optional uint32 server_version = 5;
+	optional .ServerHltvInfo tv_info = 6;
+	repeated uint32 reward_player_accounts = 7;
+	repeated uint32 idle_player_accounts = 8;
+	optional uint32 reward_item_attr_def_idx = 9;
+	optional uint32 reward_item_attr_value = 10;
+	optional uint32 reward_item_attr_reward_idx = 11;
+	optional uint32 reward_drop_list = 12;
+	optional string tournament_tag = 13;
+	optional uint32 steamdatagram_port = 14;
+}
+
+message CMsgGCCStrike15_v2_MatchmakingGC2ClientReserve {
+	optional uint64 serverid = 1;
+	optional string server_address = 7;
+	optional uint32 legacy_serverip = 2;
+	optional uint32 legacy_serverport = 3;
+	optional uint64 reservationid = 4;
+	optional .CMsgGCCStrike15_v2_MatchmakingGC2ServerReserve reservation = 5;
+	optional string map = 6;
+}
+
+message CMsgGCCStrike15_v2_MatchmakingServerRoundStats {
+	message DropInfo {
+		optional uint32 account_mvp = 1;
+	}
+
+	optional uint64 reservationid = 1;
+	optional .CMsgGCCStrike15_v2_MatchmakingGC2ServerReserve reservation = 2;
+	optional string map = 3;
+	optional int32 round = 4;
+	repeated int32 kills = 5;
+	repeated int32 assists = 6;
+	repeated int32 deaths = 7;
+	repeated int32 scores = 8;
+	repeated int32 pings = 9;
+	optional int32 round_result = 10;
+	optional int32 match_result = 11;
+	repeated int32 team_scores = 12;
+	optional .CMsgGCCStrike15_v2_MatchmakingGC2ServerConfirm confirm = 13;
+	optional int32 reservation_stage = 14;
+	optional int32 match_duration = 15;
+	repeated int32 enemy_kills = 16;
+	repeated int32 enemy_headshots = 17;
+	repeated int32 enemy_3ks = 18;
+	repeated int32 enemy_4ks = 19;
+	repeated int32 enemy_5ks = 20;
+	repeated int32 mvps = 21;
+	optional uint32 spectators_count = 22;
+	optional uint32 spectators_count_tv = 23;
+	optional uint32 spectators_count_lnk = 24;
+	repeated int32 enemy_kills_agg = 25;
+	optional .CMsgGCCStrike15_v2_MatchmakingServerRoundStats.DropInfo drop_info = 26;
+}
+
+message CMsgGCCStrike15_v2_MatchmakingServerMatchEnd {
+	optional .CMsgGCCStrike15_v2_MatchmakingServerRoundStats stats = 1;
+	optional .CMsgGCCStrike15_v2_MatchmakingGC2ServerConfirm confirm = 3;
+	optional uint64 rematch = 4;
+	optional uint32 replay_token = 5;
+	optional uint32 replay_cluster_id = 6;
+	optional bool aborted_match = 7;
+	optional .CMsgGC_ServerQuestUpdateData match_end_quest_data = 8;
+	optional uint32 server_version = 9;
+}
+
+message CMsgGCCStrike15_v2_MatchmakingClient2GCHello {
+}
+
+message CMsgGCCStrike15_v2_MatchmakingGC2ClientHello {
+	optional uint32 account_id = 1;
+	optional .CMsgGCCStrike15_v2_MatchmakingGC2ClientReserve ongoingmatch = 2;
+	optional .GlobalStatistics global_stats = 3;
+	optional uint32 penalty_seconds = 4;
+	optional uint32 penalty_reason = 5;
+	optional int32 vac_banned = 6;
+	optional .PlayerRankingInfo ranking = 7;
+	optional .PlayerCommendationInfo commendation = 8;
+	optional .PlayerMedalsInfo medals = 9;
+	optional .TournamentEvent my_current_event = 10;
+	repeated .TournamentTeam my_current_event_teams = 11;
+	optional .TournamentTeam my_current_team = 12;
+	repeated .TournamentEvent my_current_event_stages = 13;
+	optional uint32 survey_vote = 14;
+	optional .AccountActivity activity = 15;
+	optional int32 player_level = 17;
+	optional int32 player_cur_xp = 18;
+	optional int32 player_xp_bonus_flags = 19;
+}
+
+message CMsgGCCStrike15_v2_AccountPrivacySettings {
+	message Setting {
+		optional uint32 setting_type = 1;
+		optional uint32 setting_value = 2;
+	}
+
+	repeated .CMsgGCCStrike15_v2_AccountPrivacySettings.Setting settings = 1;
+}
+
+message CMsgGCCStrike15_v2_MatchmakingGC2ClientAbandon {
+	optional uint32 account_id = 1;
+	optional .CMsgGCCStrike15_v2_MatchmakingGC2ClientReserve abandoned_match = 2;
+	optional uint32 penalty_seconds = 3;
+	optional uint32 penalty_reason = 4;
+}
+
+message CMsgGCCStrike15_v2_MatchmakingServer2GCKick {
+	optional uint32 account_id = 1;
+	optional .CMsgGCCStrike15_v2_MatchmakingGC2ServerReserve reservation = 2;
+	optional uint32 reason = 3;
+}
+
+message CMsgGCCStrike15_v2_MatchmakingGC2ServerRankUpdate {
+	repeated .PlayerRankingInfo rankings = 1;
+	optional uint64 match_id = 2;
+}
+
+message CMsgGCCStrike15_v2_MatchmakingOperator2GCBlogUpdate {
+	optional string main_post_url = 1;
+}
+
+message CMsgGCCStrike15_v2_ServerNotificationForUserPenalty {
+	optional uint32 account_id = 1;
+	optional uint32 reason = 2;
+	optional uint32 seconds = 3;
+}
+
+message CMsgGCCStrike15_v2_ClientReportPlayer {
+	optional uint32 account_id = 1;
+	optional uint32 rpt_aimbot = 2;
+	optional uint32 rpt_wallhack = 3;
+	optional uint32 rpt_speedhack = 4;
+	optional uint32 rpt_teamharm = 5;
+	optional uint32 rpt_textabuse = 6;
+	optional uint32 rpt_voiceabuse = 7;
+	optional uint64 match_id = 8;
+}
+
+message CMsgGCCStrike15_v2_ClientCommendPlayer {
+	optional uint32 account_id = 1;
+	optional uint64 match_id = 8;
+	optional .PlayerCommendationInfo commendation = 9;
+	optional uint32 tokens = 10;
+}
+
+message CMsgGCCStrike15_v2_ClientReportServer {
+	optional uint32 rpt_poorperf = 1;
+	optional uint32 rpt_abusivemodels = 2;
+	optional uint32 rpt_badmotd = 3;
+	optional uint32 rpt_listingabuse = 4;
+	optional uint32 rpt_inventoryabuse = 5;
+	optional uint64 match_id = 8;
+}
+
+message CMsgGCCStrike15_v2_ClientReportResponse {
+	optional uint64 confirmation_id = 1;
+	optional uint32 account_id = 2;
+	optional uint32 server_ip = 3;
+	optional uint32 response_type = 4;
+	optional uint32 response_result = 5;
+	optional uint32 tokens = 6;
+}
+
+message CMsgGCCStrike15_v2_ClientRequestWatchInfoFriends {
+	optional uint32 request_id = 1;
+	repeated uint32 account_ids = 2;
+	optional uint64 serverid = 3;
+	optional uint64 matchid = 4;
+}
+
+message WatchableMatchInfo {
+	optional uint32 server_ip = 1;
+	optional uint32 tv_port = 2;
+	optional uint32 tv_spectators = 3;
+	optional uint32 tv_time = 4;
+	optional bytes tv_watch_password = 5;
+	optional uint64 cl_decryptdata_key = 6;
+	optional uint64 cl_decryptdata_key_pub = 7;
+	optional uint32 game_type = 8;
+	optional string game_mapgroup = 9;
+	optional string game_map = 10;
+	optional uint64 server_id = 11;
+	optional uint64 match_id = 12;
+	optional uint64 reservation_id = 13;
+}
+
+message CMsgGCCStrike15_v2_ClientRequestJoinFriendData {
+	optional uint32 version = 1;
+	optional uint32 account_id = 2;
+	optional uint32 join_token = 3;
+	optional uint32 join_ipp = 4;
+	optional .CMsgGCCStrike15_v2_MatchmakingGC2ClientReserve res = 5;
+	optional string errormsg = 6;
+}
+
+message CMsgGCCStrike15_v2_ClientRequestJoinServerData {
+	optional uint32 version = 1;
+	optional uint32 account_id = 2;
+	optional uint64 serverid = 3;
+	optional uint32 server_ip = 4;
+	optional uint32 server_port = 5;
+	optional .CMsgGCCStrike15_v2_MatchmakingGC2ClientReserve res = 6;
+}
+
+message CMsgGCCstrike15_v2_ClientRequestNewMission {
+	optional uint32 mission_id = 2;
+	optional uint32 campaign_id = 3;
+}
+
+message CMsgGCCstrike15_v2_GC2ServerNotifyXPRewarded {
+	repeated .XpProgressData xp_progress_data = 1;
+	optional uint32 account_id = 2;
+	optional uint32 current_xp = 3;
+	optional uint32 current_level = 4;
+	optional uint32 upgraded_defidx = 5;
+}
+
+message CMsgGCCStrike15_v2_WatchInfoUsers {
+	optional uint32 request_id = 1;
+	repeated uint32 account_ids = 2;
+	repeated .WatchableMatchInfo watchable_match_infos = 3;
+	optional uint32 extended_timeout = 5;
+}
+
+message CMsgGCCStrike15_v2_ClientRequestPlayersProfile {
+	optional uint32 request_id__deprecated = 1;
+	repeated uint32 account_ids__deprecated = 2;
+	optional uint32 account_id = 3;
+	optional uint32 request_level = 4;
+}
+
+message CMsgGCCStrike15_v2_PlayersProfile {
+	optional uint32 request_id = 1;
+	repeated .CMsgGCCStrike15_v2_MatchmakingGC2ClientHello account_profiles = 2;
+}
+
+message CMsgGCCStrike15_v2_PlayerOverwatchCaseUpdate {
+	optional uint64 caseid = 1;
+	optional uint32 suspectid = 3;
+	optional uint32 fractionid = 4;
+	optional uint32 rpt_aimbot = 5;
+	optional uint32 rpt_wallhack = 6;
+	optional uint32 rpt_speedhack = 7;
+	optional uint32 rpt_teamharm = 8;
+	optional uint32 reason = 9;
+}
+
+message CMsgGCCStrike15_v2_PlayerOverwatchCaseAssignment {
+	optional uint64 caseid = 1;
+	optional string caseurl = 2;
+	optional uint32 verdict = 3;
+	optional uint32 timestamp = 4;
+	optional uint32 throttleseconds = 5;
+	optional uint32 suspectid = 6;
+	optional uint32 fractionid = 7;
+	optional uint32 numrounds = 8;
+	optional uint32 fractionrounds = 9;
+	optional int32 streakconvictions = 10;
+	optional uint32 reason = 11;
+}
+
+message CMsgGCCStrike15_v2_PlayerOverwatchCaseStatus {
+	optional uint64 caseid = 1;
+	optional uint32 statusid = 2;
+}
+
+message CClientHeaderOverwatchEvidence {
+	optional uint32 accountid = 1;
+	optional uint64 caseid = 2;
+}
+
+message CMsgGCCStrike15_v2_GC2ClientTextMsg {
+	optional uint32 id = 1;
+	optional uint32 type = 2;
+	optional bytes payload = 3;
+}
+
+message CMsgGCCStrike15_v2_Client2GCTextMsg {
+	optional uint32 id = 1;
+	repeated bytes args = 2;
+}
+
+message CMsgGCCStrike15_v2_MatchEndRunRewardDrops {
+	optional .CMsgGCCStrike15_v2_MatchmakingServerReservationResponse serverinfo = 3;
+	optional .CMsgGC_ServerQuestUpdateData match_end_quest_data = 4;
+}
+
+message CEconItemPreviewDataBlock {
+	message Sticker {
+		optional uint32 slot = 1;
+		optional uint32 sticker_id = 2;
+		optional float wear = 3;
+		optional float scale = 4;
+		optional float rotation = 5;
+	}
+
+	optional uint32 accountid = 1;
+	optional uint64 itemid = 2;
+	optional uint32 defindex = 3;
+	optional uint32 paintindex = 4;
+	optional uint32 rarity = 5;
+	optional uint32 quality = 6;
+	optional uint32 paintwear = 7;
+	optional uint32 paintseed = 8;
+	optional uint32 killeaterscoretype = 9;
+	optional uint32 killeatervalue = 10;
+	optional string customname = 11;
+	repeated .CEconItemPreviewDataBlock.Sticker stickers = 12;
+	optional uint32 inventory = 13;
+	optional uint32 origin = 14;
+	optional uint32 questid = 15;
+	optional uint32 dropreason = 16;
+}
+
+message CMsgGCCStrike15_v2_MatchEndRewardDropsNotification {
+	optional .CEconItemPreviewDataBlock iteminfo = 6;
+}
+
+message CMsgItemAcknowledged {
+	optional .CEconItemPreviewDataBlock iteminfo = 1;
+}
+
+message CMsgGCCStrike15_v2_Client2GCEconPreviewDataBlockRequest {
+	optional uint64 param_s = 1;
+	optional uint64 param_a = 2;
+	optional uint64 param_d = 3;
+	optional uint64 param_m = 4;
+}
+
+message CMsgGCCStrike15_v2_Client2GCEconPreviewDataBlockResponse {
+	optional .CEconItemPreviewDataBlock iteminfo = 1;
+}
+
+message CMsgGCCStrike15_v2_TournamentMatchRewardDropsNotification {
+	optional uint64 match_id = 1;
+	optional uint32 defindex = 2;
+	repeated uint32 accountids = 3;
+}
+
+message CMsgGCCStrike15_v2_MatchListRequestCurrentLiveGames {
+}
+
+message CMsgGCCStrike15_v2_MatchListRequestLiveGameForUser {
+	optional uint32 accountid = 1;
+}
+
+message CMsgGCCStrike15_v2_MatchListRequestRecentUserGames {
+	optional uint32 accountid = 1;
+}
+
+message CMsgGCCStrike15_v2_MatchListRequestTournamentGames {
+	optional int32 eventid = 1;
+}
+
+message CMsgGCCStrike15_v2_MatchListRequestFullGameInfo {
+	optional uint64 matchid = 1;
+	optional uint64 outcomeid = 2;
+	optional uint32 token = 3;
+}
+
+message CDataGCCStrike15_v2_MatchInfo {
+	optional uint64 matchid = 1;
+	optional uint32 matchtime = 2;
+	optional .WatchableMatchInfo watchablematchinfo = 3;
+	optional .CMsgGCCStrike15_v2_MatchmakingServerRoundStats roundstats_legacy = 4;
+	repeated .CMsgGCCStrike15_v2_MatchmakingServerRoundStats roundstatsall = 5;
+}
+
+message CDataGCCStrike15_v2_TournamentGroupTeam {
+	optional int32 team_id = 1;
+	optional int32 score = 2;
+	optional bool correctpick = 3;
+}
+
+message CDataGCCStrike15_v2_TournamentGroup {
+	message Picks {
+		repeated int32 pickids = 1;
+	}
+
+	optional uint32 groupid = 1;
+	optional string name = 2;
+	optional string desc = 3;
+	optional uint32 picks__deprecated = 4;
+	repeated .CDataGCCStrike15_v2_TournamentGroupTeam teams = 5;
+	repeated int32 stage_ids = 6;
+	optional uint32 picklockuntiltime = 7;
+	optional uint32 pickableteams = 8;
+	optional uint32 points_per_pick = 9;
+	repeated .CDataGCCStrike15_v2_TournamentGroup.Picks picks = 10;
+}
+
+message CDataGCCStrike15_v2_TournamentSection {
+	optional uint32 sectionid = 1;
+	optional string name = 2;
+	optional string desc = 3;
+	repeated .CDataGCCStrike15_v2_TournamentGroup groups = 4;
+}
+
+message CDataGCCStrike15_v2_TournamentInfo {
+	repeated .CDataGCCStrike15_v2_TournamentSection sections = 1;
+	optional .TournamentEvent tournament_event = 2;
+	repeated .TournamentTeam tournament_teams = 3;
+}
+
+message CMsgGCCStrike15_v2_MatchList {
+	optional uint32 msgrequestid = 1;
+	optional uint32 accountid = 2;
+	optional uint32 servertime = 3;
+	repeated .CDataGCCStrike15_v2_MatchInfo matches = 4;
+	repeated .TournamentTeam streams = 5;
+	optional .CDataGCCStrike15_v2_TournamentInfo tournamentinfo = 6;
+}
+
+message CMsgGCCStrike15_v2_Predictions {
+	message GroupMatchTeamPick {
+		optional int32 sectionid = 1;
+		optional int32 groupid = 2;
+		optional int32 index = 3;
+		optional int32 teamid = 4;
+		optional uint64 itemid = 5;
+	}
+
+	optional uint32 event_id = 1;
+	repeated .CMsgGCCStrike15_v2_Predictions.GroupMatchTeamPick group_match_team_picks = 2;
+}
+
+message CMsgGCCStrike15_v2_Fantasy {
+	message FantasySlot {
+		optional int32 type = 1;
+		optional int32 pick = 2;
+		optional uint64 itemid = 3;
+	}
+
+	message FantasyTeam {
+		optional int32 sectionid = 1;
+		repeated .CMsgGCCStrike15_v2_Fantasy.FantasySlot slots = 2;
+	}
+
+	optional uint32 event_id = 1;
+	repeated .CMsgGCCStrike15_v2_Fantasy.FantasyTeam teams = 2;
+}
+
+message CAttribute_String {
+	optional string value = 1;
+}
+
+message CMsgGCToGCReloadVersions {
+}
+
+message CMsgCStrike15Welcome {
+	optional uint32 store_item_hash = 5;
+	optional uint32 timeplayedconsecutively = 6;
+	optional uint32 time_first_played = 10;
+	optional uint32 last_time_played = 12;
+	optional uint32 last_ip_address = 13;
+	optional uint64 gscookieid = 18;
+	optional uint64 uniqueid = 19;
+}
+
+message CMsgGCCStrike15_v2_ClientVarValueNotificationInfo {
+	optional string value_name = 1;
+	optional int32 value_int = 2;
+	optional uint32 server_addr = 3;
+	optional uint32 server_port = 4;
+	repeated string choked_blocks = 5;
+}
+
+message CMsgGCCStrike15_v2_ServerVarValueNotificationInfo {
+	optional uint32 accountid = 1;
+	repeated uint32 viewangles = 2;
+	optional uint32 type = 3;
+}
+
+message CMsgGCCStrike15_v2_GiftsLeaderboardRequest {
+}
+
+message CMsgGCCStrike15_v2_GiftsLeaderboardResponse {
+	message GiftLeaderboardEntry {
+		optional uint32 accountid = 1;
+		optional uint32 gifts = 2;
+	}
+
+	optional uint32 servertime = 1;
+	optional uint32 time_period_seconds = 2;
+	optional uint32 total_gifts_given = 3;
+	optional uint32 total_givers = 4;
+	repeated .CMsgGCCStrike15_v2_GiftsLeaderboardResponse.GiftLeaderboardEntry entries = 5;
+}
+
+message CMsgGCCStrike15_v2_ClientSubmitSurveyVote {
+	optional uint32 survey_id = 1;
+	optional uint32 vote = 2;
+}
+
+message CMsgGCCStrike15_v2_Server2GCClientValidate {
+	optional uint32 accountid = 1;
+}
+
+message CMsgGCCStrike15_v2_Server2GCPureServerValidationFailure {
+	optional uint32 accountid = 1;
+	optional string path = 2;
+	optional string file = 3;
+	optional uint32 crc = 4;
+	optional int32 hash = 5;
+	optional int32 len = 6;
+	optional int32 pack_number = 7;
+	optional int32 pack_file_id = 8;
+}
+
+message CMsgGCCStrike15_v2_GC2ClientTournamentInfo {
+	optional uint32 eventid = 1;
+	optional uint32 stageid = 2;
+	optional uint32 game_type = 3;
+	repeated uint32 teamids = 4;
+}
+
+message CSOEconCoupon {
+	optional uint32 entryid = 1 [(key_field) = true];
+	optional uint32 defidx = 2;
+	optional fixed32 expiration_date = 3;
+}
+
+message CSOQuestProgress {
+	optional uint32 questid = 1 [(key_field) = true];
+	optional uint32 points_remaining = 2;
+	optional uint32 bonus_points = 3;
+}
+
+message CSOPersonaDataPublic {
+	optional int32 player_level = 1;
+	optional .PlayerCommendationInfo commendation = 2;
+}
+
+message CMsgGC_GlobalGame_Subscribe {
+	optional uint64 ticket = 1;
+}
+
+message CMsgGC_GlobalGame_Unsubscribe {
+	optional int32 timeleft = 1;
+}
+
+message CMsgGC_GlobalGame_Play {
+	optional uint64 ticket = 1;
+	optional uint32 gametimems = 2;
+	optional uint32 msperpoint = 3;
+}
+
+message CMsgGCCStrike15_v2_AcknowledgePenalty {
+	optional int32 acknowledged = 1;
+}
+
+message CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin {
+}
+
+message CMsgGCCStrike15_v2_Client2GCStreamUnlock {
+	optional uint64 ticket = 1;
+	optional int32 os = 2;
+}
+

--- a/src/cstrike15_usermessages_public.proto
+++ b/src/cstrike15_usermessages_public.proto
@@ -61,106 +61,107 @@ import "google/protobuf/descriptor.proto";
 // for CMsgVector, etc.
 import "netmessages_public.proto";
 
+import "cstrike15_gcmessages.proto";
 //=============================================================================
 // CStrike15 User Messages
 //=============================================================================
 
-enum ECstrike15UserMessages
-{ 
-	CS_UM_VGUIMenu		= 1;
-	CS_UM_Geiger		= 2;
-	CS_UM_Train			= 3;
-	CS_UM_HudText		= 4;
-	CS_UM_SayText		= 5;
-	CS_UM_SayText2		= 6;
-	CS_UM_TextMsg		= 7;
-	CS_UM_HudMsg		= 8;
-	CS_UM_ResetHud		= 9;
-	CS_UM_GameTitle		= 10;
-	CS_UM_Shake			= 12;
-	CS_UM_Fade			= 13;			// fade HUD in/out
-	CS_UM_Rumble		= 14;
-	CS_UM_CloseCaption	= 15;
+enum ECstrike15UserMessages {
+	CS_UM_VGUIMenu = 1;
+	CS_UM_Geiger = 2;
+	CS_UM_Train = 3;
+	CS_UM_HudText = 4;
+	CS_UM_SayText = 5;
+	CS_UM_SayText2 = 6;
+	CS_UM_TextMsg = 7;
+	CS_UM_HudMsg = 8;
+	CS_UM_ResetHud = 9;
+	CS_UM_GameTitle = 10;
+	CS_UM_Shake = 12;
+	CS_UM_Fade = 13;
+	CS_UM_Rumble = 14;
+	CS_UM_CloseCaption = 15;
 	CS_UM_CloseCaptionDirect = 16;
-	CS_UM_SendAudio		= 17;
-	CS_UM_RawAudio		= 18;
-	CS_UM_VoiceMask		= 19;
-	CS_UM_RequestState  = 20;
-	CS_UM_Damage		= 21;
-	CS_UM_RadioText		= 22;
-	CS_UM_HintText		= 23;
-	CS_UM_KeyHintText	= 24;
+	CS_UM_SendAudio = 17;
+	CS_UM_RawAudio = 18;
+	CS_UM_VoiceMask = 19;
+	CS_UM_RequestState = 20;
+	CS_UM_Damage = 21;
+	CS_UM_RadioText = 22;
+	CS_UM_HintText = 23;
+	CS_UM_KeyHintText = 24;
 	CS_UM_ProcessSpottedEntityUpdate = 25;
-	CS_UM_ReloadEffect	= 26;
-	CS_UM_AdjustMoney	= 27;
-	CS_UM_UpdateTeamMoney = 28;
+	CS_UM_ReloadEffect = 26;
+	CS_UM_AdjustMoney = 27;
 	CS_UM_StopSpectatorMode = 29;
-	CS_UM_KillCam		= 30;
+	CS_UM_KillCam = 30;
 	CS_UM_DesiredTimescale = 31;
 	CS_UM_CurrentTimescale = 32;
 	CS_UM_AchievementEvent = 33;
 	CS_UM_MatchEndConditions = 34;
 	CS_UM_DisconnectToLobby = 35;
+	CS_UM_PlayerStatsUpdate = 36;
 	CS_UM_DisplayInventory = 37;
-	CS_UM_WarmupHasEnded = 38;	
+	CS_UM_WarmupHasEnded = 38;
 	CS_UM_ClientInfo = 39;
+	CS_UM_XRankGet = 40;
+	CS_UM_XRankUpd = 41;
 	CS_UM_CallVoteFailed = 45;
 	CS_UM_VoteStart = 46;
 	CS_UM_VotePass = 47;
 	CS_UM_VoteFailed = 48;
 	CS_UM_VoteSetup = 49;
+	CS_UM_ServerRankRevealAll = 50;
 	CS_UM_SendLastKillerDamageToClient = 51;
+	CS_UM_ServerRankUpdate = 52;
 	CS_UM_ItemPickup = 53;
-	CS_UM_ShowMenu = 54;					// show hud menu
-	CS_UM_BarTime = 55;						// For the C4 progress bar.
+	CS_UM_ShowMenu = 54;
+	CS_UM_BarTime = 55;
 	CS_UM_AmmoDenied = 56;
 	CS_UM_MarkAchievement = 57;
+	CS_UM_MatchStatsUpdate = 58;
 	CS_UM_ItemDrop = 59;
 	CS_UM_GlowPropTurnOff = 60;
+	CS_UM_SendPlayerItemDrops = 61;
+	CS_UM_RoundBackupFilenames = 62;
+	CS_UM_SendPlayerItemFound = 63;
+	CS_UM_ReportHit = 64;
+	CS_UM_XpUpdate = 65;
+	CS_UM_QuestProgress = 66;
+	CS_UM_ScoreLeaderboardData = 67;
 }
 
-//=============================================================================
-
-
-message CCSUsrMsg_VGUIMenu
-{
-	optional string name = 1;
-	optional bool show = 2;
-
-	message Subkey
-	{
+message CCSUsrMsg_VGUIMenu {
+	message Subkey {
 		optional string name = 1;
 		optional string str = 2;
 	}
 
-	repeated Subkey subkeys = 3;
+	optional string name = 1;
+	optional bool show = 2;
+	repeated .CCSUsrMsg_VGUIMenu.Subkey subkeys = 3;
 }
 
-message CCSUsrMsg_Geiger
-{
+message CCSUsrMsg_Geiger {
 	optional int32 range = 1;
 }
 
-message CCSUsrMsg_Train
-{
+message CCSUsrMsg_Train {
 	optional int32 train = 1;
 }
 
-message CCSUsrMsg_HudText
-{
+message CCSUsrMsg_HudText {
 	optional string text = 1;
 }
 
-message CCSUsrMsg_SayText
-{
+message CCSUsrMsg_SayText {
 	optional int32 ent_idx = 1;
 	optional string text = 2;
 	optional bool chat = 3;
 	optional bool textallchat = 4;
 }
 
-message CCSUsrMsg_SayText2
-{
+message CCSUsrMsg_SayText2 {
 	optional int32 ent_idx = 1;
 	optional bool chat = 2;
 	optional string msg_name = 3;
@@ -168,14 +169,12 @@ message CCSUsrMsg_SayText2
 	optional bool textallchat = 5;
 }
 
-message CCSUsrMsg_TextMsg
-{
+message CCSUsrMsg_TextMsg {
 	optional int32 msg_dst = 1;
 	repeated string params = 3;
 }
 
-message CCSUsrMsg_HudMsg
-{
+message CCSUsrMsg_HudMsg {
 	optional int32 channel = 1;
 	optional CMsgVector2D pos = 2;
 	optional CMsgRGBA clr1 = 3;
@@ -185,101 +184,85 @@ message CCSUsrMsg_HudMsg
 	optional float fade_out_time = 7;
 	optional float hold_time = 9;
 	optional float fx_time = 10;
-	optional string text = 11; 
+	optional string text = 11;
 }
 
-message CCSUsrMsg_Shake
-{
+message CCSUsrMsg_Shake {
 	optional int32 command = 1;
 	optional float local_amplitude = 2;
 	optional float frequency = 3;
 	optional float duration = 4;
 }
 
-message CCSUsrMsg_Fade
-{
+message CCSUsrMsg_Fade {
 	optional int32 duration = 1;
 	optional int32 hold_time = 2;
-	optional int32 flags = 3;		// fade type (in / out)
+	optional int32 flags = 3;
 	optional CMsgRGBA clr = 4;
 }
 
-message CCSUsrMsg_Rumble
-{
+message CCSUsrMsg_Rumble {
 	optional int32 index = 1;
 	optional int32 data = 2;
 	optional int32 flags = 3;
 }
 
-message CCSUsrMsg_CloseCaption
-{
+message CCSUsrMsg_CloseCaption {
 	optional uint32 hash = 1;
 	optional int32 duration = 2;
 	optional bool from_player = 3;
 }
 
-message CCSUsrMsg_CloseCaptionDirect
-{
+message CCSUsrMsg_CloseCaptionDirect {
 	optional uint32 hash = 1;
 	optional int32 duration = 2;
 	optional bool from_player = 3;
 }
 
-message CCSUsrMsg_SendAudio
-{
+message CCSUsrMsg_SendAudio {
 	optional string radio_sound = 1;
 }
 
-message CCSUsrMsg_RawAudio
-{
+message CCSUsrMsg_RawAudio {
 	optional int32 pitch = 1;
 	optional int32 entidx = 2;
 	optional float duration = 3;
 	optional string voice_filename = 4;
 }
 
-message CCSUsrMsg_VoiceMask
-{
-	message PlayerMask
-	{
+message CCSUsrMsg_VoiceMask {
+	message PlayerMask {
 		optional int32 game_rules_mask = 1;
 		optional int32 ban_masks = 2;
 	}
 
-	repeated PlayerMask player_masks = 1;
+	repeated .CCSUsrMsg_VoiceMask.PlayerMask player_masks = 1;
 	optional bool player_mod_enable = 2;
 }
 
-message CCSUsrMsg_Damage
-{
+message CCSUsrMsg_Damage {
 	optional int32 amount = 1;
 	optional CMsgVector inflictor_world_pos = 2;
+	optional int32 victim_entindex = 3;
 }
 
-message CCSUsrMsg_RadioText
-{
+message CCSUsrMsg_RadioText {
 	optional int32 msg_dst = 1;
 	optional int32 client = 2;
 	optional string msg_name = 3;
 	repeated string params = 4;
 }
 
-message CCSUsrMsg_HintText
-{
+message CCSUsrMsg_HintText {
 	optional string text = 1;
 }
 
-message CCSUsrMsg_KeyHintText
-{
+message CCSUsrMsg_KeyHintText {
 	repeated string hints = 1;
 }
 
-message CCSUsrMsg_ProcessSpottedEntityUpdate
-{
-	optional bool new_update = 1;
-	
-	message SpottedEntityUpdate
-	{
+message CCSUsrMsg_ProcessSpottedEntityUpdate {
+	message SpottedEntityUpdate {
 		optional int32 entity_idx = 1;
 		optional int32 class_id = 2;
 		optional int32 origin_x = 3;
@@ -291,70 +274,113 @@ message CCSUsrMsg_ProcessSpottedEntityUpdate
 		optional bool player_has_c4 = 9;
 	}
 
-	repeated SpottedEntityUpdate entity_updates = 2;
+	optional bool new_update = 1;
+	repeated .CCSUsrMsg_ProcessSpottedEntityUpdate.SpottedEntityUpdate entity_updates = 2;
 }
 
-message CCSUsrMsg_ReloadEffect
-{
+message CCSUsrMsg_SendPlayerItemDrops {
+	repeated .CEconItemPreviewDataBlock entity_updates = 1;
+}
+
+message CCSUsrMsg_SendPlayerItemFound {
+	optional CEconItemPreviewDataBlock iteminfo = 1;
+	optional int32 entindex = 2;
+}
+
+message CCSUsrMsg_ReloadEffect {
 	optional int32 entidx = 1;
 	optional int32 actanim = 2;
+	optional float origin_x = 3;
+	optional float origin_y = 4;
+	optional float origin_z = 5;
 }
 
-message CCSUsrMsg_AdjustMoney
-{
+message CCSUsrMsg_AdjustMoney {
 	optional int32 amount = 1;
 }
 
-message CCSUsrMsg_KillCam
-{
+message CCSUsrMsg_ReportHit {
+	optional float pos_x = 1;
+	optional float pos_y = 2;
+	optional float timestamp = 4;
+	optional float pos_z = 3;
+}
+
+message CCSUsrMsg_KillCam {
 	optional int32 obs_mode = 1;
 	optional int32 first_target = 2;
 	optional int32 second_target = 3;
 }
 
-message CCSUsrMsg_DesiredTimescale
-{
+message CCSUsrMsg_DesiredTimescale {
 	optional float desired_timescale = 1;
 	optional float duration_realtime_sec = 2;
 	optional int32 interpolator_type = 3;
 	optional float start_blend_time = 4;
 }
 
-message CCSUsrMsg_CurrentTimescale
-{
+message CCSUsrMsg_CurrentTimescale {
 	optional float cur_timescale = 1;
 }
 
-message CCSUsrMsg_AchievementEvent
-{
+message CCSUsrMsg_AchievementEvent {
 	optional int32 achievement = 1;
 	optional int32 count = 2;
 	optional int32 user_id = 3;
 }
 
-
-message CCSUsrMsg_MatchEndConditions
-{
+message CCSUsrMsg_MatchEndConditions {
 	optional int32 fraglimit = 1;
 	optional int32 mp_maxrounds = 2;
 	optional int32 mp_winlimit = 3;
 	optional int32 mp_timelimit = 4;
 }
 
-message CCSUsrMsg_DisplayInventory
-{
+message CCSUsrMsg_PlayerStatsUpdate {
+	message Stat {
+		optional int32 idx = 1;
+		optional int32 delta = 2;
+	}
+
+	optional int32 version = 1;
+	repeated .CCSUsrMsg_PlayerStatsUpdate.Stat stats = 4;
+	optional int32 user_id = 5;
+	optional int32 crc = 6;
+}
+
+message CCSUsrMsg_DisplayInventory {
 	optional bool display = 1;
 	optional int32 user_id = 2;
 }
 
-message CCSUsrMsg_CallVoteFailed
-{
+message CCSUsrMsg_QuestProgress {
+	optional uint32 quest_id = 1;
+	optional uint32 normal_points = 2;
+	optional uint32 bonus_points = 3;
+	optional bool is_event_quest = 4;
+}
+
+message CCSUsrMsg_ScoreLeaderboardData {
+	optional ScoreLeaderboardData data = 1;
+}
+
+message CCSUsrMsg_XRankGet {
+	optional int32 mode_idx = 1;
+	optional int32 controller = 2;
+}
+
+message CCSUsrMsg_XRankUpd {
+	optional int32 mode_idx = 1;
+	optional int32 controller = 2;
+	optional int32 ranking = 3;
+}
+
+message CCSUsrMsg_CallVoteFailed {
 	optional int32 reason = 1;
 	optional int32 time = 2;
 }
 
-message CCSUsrMsg_VoteStart
-{
+message CCSUsrMsg_VoteStart {
 	optional int32 team = 1;
 	optional int32 ent_idx = 2;
 	optional int32 vote_type = 3;
@@ -362,118 +388,119 @@ message CCSUsrMsg_VoteStart
 	optional string details_str = 5;
 	optional string other_team_str = 6;
 	optional bool is_yes_no_vote = 7;
-
 }
 
-message CCSUsrMsg_VotePass
-{
+message CCSUsrMsg_VotePass {
 	optional int32 team = 1;
 	optional int32 vote_type = 2;
-	optional string disp_str= 3;
+	optional string disp_str = 3;
 	optional string details_str = 4;
 }
 
-message CCSUsrMsg_VoteFailed
-{
+message CCSUsrMsg_VoteFailed {
 	optional int32 team = 1;
-	optional int32 reason = 2;	
+	optional int32 reason = 2;
 }
 
-message CCSUsrMsg_VoteSetup
-{
+message CCSUsrMsg_VoteSetup {
 	repeated string potential_issues = 1;
 }
 
-message CCSUsrMsg_SendLastKillerDamageToClient
-{
+message CCSUsrMsg_SendLastKillerDamageToClient {
 	optional int32 num_hits_given = 1;
 	optional int32 damage_given = 2;
 	optional int32 num_hits_taken = 3;
 	optional int32 damage_taken = 4;
 }
 
-message CCSUsrMsg_ItemPickup
-{
+message CCSUsrMsg_ServerRankUpdate {
+	message RankUpdate {
+		optional int32 account_id = 1;
+		optional int32 rank_old = 2;
+		optional int32 rank_new = 3;
+		optional int32 num_wins = 4;
+		optional float rank_change = 5;
+	}
+
+	repeated .CCSUsrMsg_ServerRankUpdate.RankUpdate rank_update = 1;
+}
+
+message CCSUsrMsg_XpUpdate {
+	optional CMsgGCCstrike15_v2_GC2ServerNotifyXPRewarded data = 1;
+}
+
+message CCSUsrMsg_ItemPickup {
 	optional string item = 1;
 }
 
-message CCSUsrMsg_ShowMenu
-{
+message CCSUsrMsg_ShowMenu {
 	optional int32 bits_valid_slots = 1;
 	optional int32 display_time = 2;
-	optional string menu_string = 3;	
+	optional string menu_string = 3;
 }
 
-message CCSUsrMsg_BarTime
-{
+message CCSUsrMsg_BarTime {
 	optional string time = 1;
 }
 
-message CCSUsrMsg_AmmoDenied
-{
+message CCSUsrMsg_AmmoDenied {
 	optional int32 ammoIdx = 1;
 }
 
-message CCSUsrMsg_MarkAchievement
-{
+message CCSUsrMsg_MarkAchievement {
 	optional string achievement = 1;
 }
 
-message CCSUsrMsg_ItemDrop
-{
+message CCSUsrMsg_MatchStatsUpdate {
+	optional string update = 1;
+}
+
+message CCSUsrMsg_ItemDrop {
 	optional int64 itemid = 1;
 	optional bool death = 2;
 }
 
-message CCSUsrMsg_GlowPropTurnOff
-{
+message CCSUsrMsg_GlowPropTurnOff {
 	optional int32 entidx = 1;
 }
 
-message CCSUsrMsg_RoundBackupFilenames
-{
+message CCSUsrMsg_RoundBackupFilenames {
 	optional int32 count = 1;
 	optional int32 index = 2;
-    optional string filename = 3;
-    optional string nicename = 4;
+	optional string filename = 3;
+	optional string nicename = 4;
 }
 
-
-//=============================================================================
-// Messages where the data is irrelevant
-//=============================================================================
-
-message CCSUsrMsg_ResetHud
-{
+message CCSUsrMsg_ResetHud {
 	optional bool reset = 1;
 }
 
-message CCSUsrMsg_GameTitle
-{
+message CCSUsrMsg_GameTitle {
 	optional int32 dummy = 1;
 }
 
-message CCSUsrMsg_RequestState
-{
+message CCSUsrMsg_RequestState {
 	optional int32 dummy = 1;
 }
 
-message CCSUsrMsg_StopSpectatorMode
-{
+message CCSUsrMsg_StopSpectatorMode {
 	optional int32 dummy = 1;
 }
 
-message CCSUsrMsg_DisconnectToLobby
-{
+message CCSUsrMsg_DisconnectToLobby {
 	optional int32 dummy = 1;
 }
 
-message CCSUsrMsg_WarmupHasEnded
-{
+message CCSUsrMsg_WarmupHasEnded {
 	optional int32 dummy = 1;
 }
 
-message CCSUsrMsg_ClientInfo
-{
+message CCSUsrMsg_ClientInfo {
 	optional int32 dummy = 1;
 }
+
+message CCSUsrMsg_ServerRankRevealAll {
+	optional int32 seconds_till_shutdown = 1;
+}
+
+

--- a/src/demofiledump.cpp
+++ b/src/demofiledump.cpp
@@ -31,6 +31,8 @@
 #include "google/protobuf/reflection_ops.h"
 #include "google/protobuf/descriptor.pb.h"
 
+#include "generated_proto/cstrike15_gcmessages.pb.h"
+#include "generated_proto/steammessages.pb.h"
 #include "generated_proto/cstrike15_usermessages_public.pb.h"
 #include "generated_proto/netmessages_public.pb.h"
 
@@ -161,22 +163,35 @@ void CDemoFileDump::DumpUserMessage( const void *parseBuffer, int BufferSize )
 			HANDLE_UserMsg( AchievementEvent );
 			HANDLE_UserMsg( MatchEndConditions );
 			HANDLE_UserMsg( DisconnectToLobby );
+			HANDLE_UserMsg( PlayerStatsUpdate );
 			HANDLE_UserMsg( DisplayInventory );
 			HANDLE_UserMsg( WarmupHasEnded );
 			HANDLE_UserMsg( ClientInfo );
+			HANDLE_UserMsg( XRankGet );
+			HANDLE_UserMsg( XRankUpd );
 			HANDLE_UserMsg( CallVoteFailed );
 			HANDLE_UserMsg( VoteStart );
 			HANDLE_UserMsg( VotePass );
 			HANDLE_UserMsg( VoteFailed );
 			HANDLE_UserMsg( VoteSetup );
+			HANDLE_UserMsg( ServerRankRevealAll );
 			HANDLE_UserMsg( SendLastKillerDamageToClient );
+			HANDLE_UserMsg( ServerRankUpdate );
 			HANDLE_UserMsg( ItemPickup );
 			HANDLE_UserMsg( ShowMenu );
 			HANDLE_UserMsg( BarTime );
 			HANDLE_UserMsg( AmmoDenied );
 			HANDLE_UserMsg( MarkAchievement );
+			HANDLE_UserMsg( MatchStatsUpdate );
 			HANDLE_UserMsg( ItemDrop );
 			HANDLE_UserMsg( GlowPropTurnOff );
+			HANDLE_UserMsg( SendPlayerItemDrops );
+			HANDLE_UserMsg( RoundBackupFilenames );
+			HANDLE_UserMsg( SendPlayerItemFound );
+			HANDLE_UserMsg( ReportHit );
+			HANDLE_UserMsg( XpUpdate );
+			HANDLE_UserMsg( QuestProgress );
+			HANDLE_UserMsg( ScoreLeaderboardData );
 
 #undef HANDLE_UserMsg
 		}

--- a/src/demofiledump.h
+++ b/src/demofiledump.h
@@ -29,6 +29,8 @@
 #include "demofilebitbuf.h"
 #include "demofilepropdecode.h"
 
+
+#include "generated_proto/steammessages.pb.h"
 #include "generated_proto/netmessages_public.pb.h"
 
 #define NET_MAX_PAYLOAD					( 262144 - 4 )		// largest message we can send in bytes

--- a/src/demofilepropdecode.cpp
+++ b/src/demofilepropdecode.cpp
@@ -29,6 +29,9 @@
 #include "google/protobuf/reflection_ops.h"
 #include "google/protobuf/descriptor.pb.h"
 
+
+#include "generated_proto/cstrike15_gcmessages.pb.h"
+#include "generated_proto/steammessages.pb.h"
 #include "generated_proto/cstrike15_usermessages_public.pb.h"
 #include "generated_proto/netmessages_public.pb.h"
 

--- a/src/netmessages_public.proto
+++ b/src/netmessages_public.proto
@@ -71,214 +71,299 @@ option cc_generic_services = false;
 
 import "google/protobuf/descriptor.proto";
 
-//=============================================================================
-// Common Types
-//=============================================================================
+enum NET_Messages {
+	net_NOP = 0;
+	net_Disconnect = 1;
+	net_File = 2;
+	net_SplitScreenUser = 3;
+	net_Tick = 4;
+	net_StringCmd = 5;
+	net_SetConVar = 6;
+	net_SignonState = 7;
+	net_PlayerAvatarData = 100;
+}
 
-message CMsgVector
-{
+enum CLC_Messages {
+	clc_ClientInfo = 8;
+	clc_Move = 9;
+	clc_VoiceData = 10;
+	clc_BaselineAck = 11;
+	clc_ListenEvents = 12;
+	clc_RespondCvarValue = 13;
+	clc_FileCRCCheck = 14;
+	clc_LoadingProgress = 15;
+	clc_SplitPlayerConnect = 16;
+	clc_ClientMessage = 17;
+	clc_CmdKeyValues = 18;
+	clc_HltvReplay = 20;
+}
+
+enum VoiceDataFormat_t {
+	VOICEDATA_FORMAT_STEAM = 0;
+	VOICEDATA_FORMAT_ENGINE = 1;
+}
+
+enum ESplitScreenMessageType {
+	option allow_alias = true;
+	MSG_SPLITSCREEN_ADDUSER = 0;
+	MSG_SPLITSCREEN_REMOVEUSER = 1;
+	MSG_SPLITSCREEN_TYPE_BITS = 1;
+}
+
+enum SVC_Messages {
+	svc_ServerInfo = 8;
+	svc_SendTable = 9;
+	svc_ClassInfo = 10;
+	svc_SetPause = 11;
+	svc_CreateStringTable = 12;
+	svc_UpdateStringTable = 13;
+	svc_VoiceInit = 14;
+	svc_VoiceData = 15;
+	svc_Print = 16;
+	svc_Sounds = 17;
+	svc_SetView = 18;
+	svc_FixAngle = 19;
+	svc_CrosshairAngle = 20;
+	svc_BSPDecal = 21;
+	svc_SplitScreen = 22;
+	svc_UserMessage = 23;
+	svc_EntityMessage = 24;
+	svc_GameEvent = 25;
+	svc_PacketEntities = 26;
+	svc_TempEntities = 27;
+	svc_Prefetch = 28;
+	svc_Menu = 29;
+	svc_GameEventList = 30;
+	svc_GetCvarValue = 31;
+	svc_PaintmapData = 33;
+	svc_CmdKeyValues = 34;
+	svc_EncryptedData = 35;
+	svc_HltvReplay = 36;
+}
+
+enum ReplayEventType_t {
+	REPLAY_EVENT_CANCEL = 0;
+	REPLAY_EVENT_DEATH = 1;
+	REPLAY_EVENT_GENERIC = 2;
+	REPLAY_EVENT_STUCK_NEED_FULL_UPDATE = 3;
+}
+
+message CMsgVector {
 	optional float x = 1;
 	optional float y = 2;
 	optional float z = 3;
 }
 
-message CMsgVector2D
-{
+message CMsgVector2D {
 	optional float x = 1;
 	optional float y = 2;
 }
 
-message CMsgQAngle
-{
+message CMsgQAngle {
 	optional float x = 1;
 	optional float y = 2;
 	optional float z = 3;
 }
 
-message CMsgRGBA
-{
+message CMsgRGBA {
 	optional int32 r = 1;
 	optional int32 g = 2;
 	optional int32 b = 3;
 	optional int32 a = 4;
 }
 
-//=============================================================================
-// Bidirectional NET Messages
-//=============================================================================
-
-enum NET_Messages
-{
-	net_NOP = 0;
-	net_Disconnect = 1;				// disconnect, last message in connection
-	net_File = 2;					// file transmission message request/deny
-	net_Tick = 4; 					// s->c world tick, c->s ack world tick
-	net_StringCmd = 5; 				// a string command
-	net_SetConVar = 6;				// sends one/multiple convar/userinfo settings
-	net_SignonState = 7;			// signals or acks current signon state
+message CNETMsg_Tick {
+	optional uint32 tick = 1;
+	optional uint32 host_computationtime = 4;
+	optional uint32 host_computationtime_std_deviation = 5;
+	optional uint32 host_framestarttime_std_deviation = 6;
+	optional uint32 hltv_replay_flags = 7;
 }
 
-message CNETMsg_Tick
-{
-	optional uint32 tick = 1;							// current tick count
-	optional uint32 host_computationtime = 4;			// Host frame computation time in usec (1/1,000,000th sec) - will be say 4 ms when server is running at 25% CPU load for 64-tick server
-	optional uint32 host_computationtime_std_deviation = 5;	// Host frame computation time stddev in usec (1/1,000,000th sec)
-	optional uint32 host_framestarttime_std_deviation = 6; // Host frame start time stddev in usec (1/1,000,000th sec) - measures how precisely we can wake up from sleep when meeting server framerate
-}
-
-message CNETMsg_StringCmd
-{
+message CNETMsg_StringCmd {
 	optional string command = 1;
 }
 
-message CNETMsg_SignonState
-{
-	optional uint32 signon_state = 1;				// See SIGNONSTATE_ defines
-	optional uint32 spawn_count = 2;				// server spawn count (session number)
-	optional uint32 num_server_players	 = 3; 		// Number of players the server discloses as connected to the server
-	repeated string players_networkids = 4;			// player network ids
-	optional string map_name = 5;					// Name of the current map
+message CNETMsg_SignonState {
+	optional uint32 signon_state = 1;
+	optional uint32 spawn_count = 2;
+	optional uint32 num_server_players = 3;
+	repeated string players_networkids = 4;
+	optional string map_name = 5;
 }
 
-message CMsg_CVars
-{
-	message CVar
-	{
+message CMsg_CVars {
+	message CVar {
 		optional string name = 1;
 		optional string value = 2;
+		optional uint32 dictionary_name = 3;
 	}
 
-	repeated CVar cvars = 1;
+	repeated .CMsg_CVars.CVar cvars = 1;
 }
 
-message CNETMsg_SetConVar
-{
-	optional CMsg_CVars convars = 1;
+message CNETMsg_SetConVar {
+	optional .CMsg_CVars convars = 1;
 }
 
-message CNETMsg_NOP
-{
+message CNETMsg_NOP {
 }
 
-message CNETMsg_Disconnect
-{
+message CNETMsg_Disconnect {
 	optional string text = 1;
 }
 
-message CNETMsg_File
-{
+message CNETMsg_File {
 	optional int32 transfer_id = 1;
 	optional string file_name = 2;
 	optional bool is_replay_demo_file = 3;
 	optional bool deny = 4;
 }
 
-//=============================================================================
-// Server messages
-//=============================================================================
-
-enum SVC_Messages
-{
-	svc_ServerInfo 			= 8;		// first message from server about game; map etc
-	svc_SendTable 			= 9;		// sends a sendtable description for a game class
-	svc_ClassInfo 			= 10;		// Info about classes (first byte is a CLASSINFO_ define).							
-	svc_SetPause 			= 11;		// tells client if server paused or unpaused
-	svc_CreateStringTable 	= 12;		// inits shared string tables
-	svc_UpdateStringTable 	= 13;		// updates a string table
-	svc_VoiceInit 			= 14;		// inits used voice codecs & quality
-	svc_VoiceData 			= 15;		// Voicestream data from the server
-	svc_Print 				= 16;		// print text to console
-	svc_Sounds 				= 17;		// starts playing sound
-	svc_SetView 			= 18;		// sets entity as point of view
-	svc_FixAngle 			= 19;		// sets/corrects players viewangle
-	svc_CrosshairAngle 		= 20;		// adjusts crosshair in auto aim mode to lock on traget
-	svc_BSPDecal 			= 21;		// add a static decal to the world BSP
-	svc_UserMessage 		= 23;		// a game specific message 
-	svc_GameEvent 			= 25;		// global game event fired
-	svc_PacketEntities 		= 26;		// non-delta compressed entities
-	svc_TempEntities 		= 27;		// non-reliable event object
-	svc_Prefetch 			= 28;		// only sound indices for now
-	svc_Menu 				= 29;		// display a menu from a plugin
-	svc_GameEventList 		= 30;		// list of known games events and fields
-	svc_GetCvarValue 		= 31;		// Server wants to know the value of a cvar on the client	
+message CNETMsg_SplitScreenUser {
+	optional int32 slot = 1;
 }
 
-message CSVCMsg_ServerInfo
-{
-	optional int32 protocol = 1;			// protocol version
-	optional int32 server_count = 2;		// number of changelevels since server start
-	optional bool is_dedicated = 3;  		// dedicated server ?	
+message CNETMsg_PlayerAvatarData {
+	optional uint32 accountid = 1;
+	optional bytes rgb = 2;
+}
+
+message CCLCMsg_ClientInfo {
+	optional fixed32 send_table_crc = 1;
+	optional uint32 server_count = 2;
+	optional bool is_hltv = 3;
+	optional bool is_replay = 4;
+	optional uint32 friends_id = 5;
+	optional string friends_name = 6;
+	repeated fixed32 custom_files = 7;
+}
+
+message CCLCMsg_Move {
+	optional uint32 num_backup_commands = 1;
+	optional uint32 num_new_commands = 2;
+	optional bytes data = 3;
+}
+
+message CCLCMsg_VoiceData {
+	optional bytes data = 1;
+	optional fixed64 xuid = 2;
+	optional .VoiceDataFormat_t format = 3 [default = VOICEDATA_FORMAT_ENGINE];
+	optional int32 sequence_bytes = 4;
+	optional uint32 section_number = 5;
+	optional uint32 uncompressed_sample_offset = 6;
+}
+
+message CCLCMsg_BaselineAck {
+	optional int32 baseline_tick = 1;
+	optional int32 baseline_nr = 2;
+}
+
+message CCLCMsg_ListenEvents {
+	repeated fixed32 event_mask = 1;
+}
+
+message CCLCMsg_RespondCvarValue {
+	optional int32 cookie = 1;
+	optional int32 status_code = 2;
+	optional string name = 3;
+	optional string value = 4;
+}
+
+message CCLCMsg_FileCRCCheck {
+	optional int32 code_path = 1;
+	optional string path = 2;
+	optional int32 code_filename = 3;
+	optional string filename = 4;
+	optional int32 file_fraction = 5;
+	optional bytes md5 = 6;
+	optional uint32 crc = 7;
+	optional int32 file_hash_type = 8;
+	optional int32 file_len = 9;
+	optional int32 pack_file_id = 10;
+	optional int32 pack_file_number = 11;
+}
+
+message CCLCMsg_LoadingProgress {
+	optional int32 progress = 1;
+}
+
+message CCLCMsg_SplitPlayerConnect {
+	optional .CMsg_CVars convars = 1;
+}
+
+message CCLCMsg_CmdKeyValues {
+	optional bytes keyvalues = 1;
+}
+
+message CSVCMsg_ServerInfo {
+	optional int32 protocol = 1;
+	optional int32 server_count = 2;
+	optional bool is_dedicated = 3;
 	optional bool is_official_valve_server = 4;
-	optional bool is_hltv = 5;				// HLTV server ?
-	optional bool is_replay = 6;			// Replay server ?
-	optional bool is_redirecting_to_proxy_relay = 21;	// // Will be redirecting to proxy relay
-	optional int32 c_os = 7;				// L = linux, W = Win32
-	optional fixed32 map_crc = 8;			// server map CRC
-	optional fixed32 client_crc = 9;		// client.dll CRC server is using
-	optional fixed32 string_table_crc = 10;	// string table CRC server is using
-	optional int32 max_clients = 11;		// max number of clients on server
-	optional int32 max_classes = 12;		// max number of server classes
-	optional int32 player_slot = 13;		// our client slot number
-	optional float tick_interval = 14;		// server tick interval
-	optional string game_dir = 15;			// game directory eg "tf2"
-	optional string map_name = 16;			// name of current map 
-	optional string map_group_name = 17;	// name of current map 
-	optional string sky_name = 18;			// name of current skybox 
-	optional string host_name = 19;			// server name
-	optional uint64 ugc_map_id = 22;	
+	optional bool is_hltv = 5;
+	optional bool is_replay = 6;
+	optional bool is_redirecting_to_proxy_relay = 21;
+	optional int32 c_os = 7;
+	optional fixed32 map_crc = 8;
+	optional fixed32 client_crc = 9;
+	optional fixed32 string_table_crc = 10;
+	optional int32 max_clients = 11;
+	optional int32 max_classes = 12;
+	optional int32 player_slot = 13;
+	optional float tick_interval = 14;
+	optional string game_dir = 15;
+	optional string map_name = 16;
+	optional string map_group_name = 17;
+	optional string sky_name = 18;
+	optional string host_name = 19;
+	optional uint32 public_ip = 20;
+	optional uint64 ugc_map_id = 22;
 }
 
-message CSVCMsg_ClassInfo
-{
-	message class_t
-	{
+message CSVCMsg_ClassInfo {
+	message class_t {
 		optional int32 class_id = 1;
 		optional string data_table_name = 2;
 		optional string class_name = 3;
 	}
 
-	optional bool create_on_client = 1;	
-	repeated class_t classes = 2;
+	optional bool create_on_client = 1;
+	repeated .CSVCMsg_ClassInfo.class_t classes = 2;
 }
 
-message CSVCMsg_SendTable
-{
-	message sendprop_t
-	{
-		optional int32 type = 1;				// SendPropType
+message CSVCMsg_SendTable {
+	message sendprop_t {
+		optional int32 type = 1;
 		optional string var_name = 2;
 		optional int32 flags = 3;
 		optional int32 priority = 4;
-		optional string dt_name = 5;			// if pProp->m_Type == DPT_DataTable || IsExcludeProp
-		optional int32 num_elements = 6;		// else if pProp->m_Type == DPT_Array
-		optional float low_value = 7;			// else ...
-		optional float high_value = 8;			// 		...
-		optional int32 num_bits = 9;			//		...
-	};
+		optional string dt_name = 5;
+		optional int32 num_elements = 6;
+		optional float low_value = 7;
+		optional float high_value = 8;
+		optional int32 num_bits = 9;
+	}
 
 	optional bool is_end = 1;
 	optional string net_table_name = 2;
 	optional bool needs_decoder = 3;
-	repeated sendprop_t props = 4;
+	repeated .CSVCMsg_SendTable.sendprop_t props = 4;
 }
 
-message CSVCMsg_Print
-{
+message CSVCMsg_Print {
 	optional string text = 1;
 }
 
-message CSVCMsg_SetPause
-{
+message CSVCMsg_SetPause {
 	optional bool paused = 1;
 }
 
-message CSVCMsg_SetView
-{
+message CSVCMsg_SetView {
 	optional int32 entity_index = 1;
 }
 
-message CSVCMsg_CreateStringTable
-{
+message CSVCMsg_CreateStringTable {
 	optional string name = 1;
 	optional int32 max_entries = 2;
 	optional int32 num_entries = 3;
@@ -289,150 +374,182 @@ message CSVCMsg_CreateStringTable
 	optional bytes string_data = 8;
 }
 
-message CSVCMsg_UpdateStringTable
-{
+message CSVCMsg_UpdateStringTable {
 	optional int32 table_id = 1;
 	optional int32 num_changed_entries = 2;
 	optional bytes string_data = 3;
 }
 
-message CSVCMsg_VoiceInit
-{
+message CSVCMsg_VoiceInit {
 	optional int32 quality = 1;
 	optional string codec = 2;
+	optional int32 version = 3 [default = 0];
 }
 
-message CSVCMsg_VoiceData
-{
+message CSVCMsg_VoiceData {
 	optional int32 client = 1;
 	optional bool proximity = 2;
 	optional fixed64 xuid = 3;
-	optional int32 audible_mask = 4; 
-	optional bytes voice_data = 5;	
+	optional int32 audible_mask = 4;
+	optional bytes voice_data = 5;
+	optional bool caster = 6;
+	optional .VoiceDataFormat_t format = 7 [default = VOICEDATA_FORMAT_ENGINE];
+	optional int32 sequence_bytes = 8;
+	optional uint32 section_number = 9;
+	optional uint32 uncompressed_sample_offset = 10;
 }
 
-message CSVCMsg_FixAngle
-{
+message CSVCMsg_FixAngle {
 	optional bool relative = 1;
-	optional CMsgQAngle angle = 2;
+	optional .CMsgQAngle angle = 2;
 }
 
-message CSVCMsg_CrosshairAngle
-{
-	optional CMsgQAngle angle = 1;
+message CSVCMsg_CrosshairAngle {
+	optional .CMsgQAngle angle = 1;
 }
 
-message CSVCMsg_Prefetch
-{
+message CSVCMsg_Prefetch {
 	optional int32 sound_index = 1;
 }
 
-message CSVCMsg_BSPDecal
-{
-	optional CMsgVector pos = 1;
+message CSVCMsg_BSPDecal {
+	optional .CMsgVector pos = 1;
 	optional int32 decal_texture_index = 2;
 	optional int32 entity_index = 3;
 	optional int32 model_index = 4;
 	optional bool low_priority = 5;
 }
 
-message CSVCMsg_GetCvarValue
-{
-	optional int32 cookie = 1;		// QueryCvarCookie_t
+message CSVCMsg_SplitScreen {
+	optional .ESplitScreenMessageType type = 1 [default = MSG_SPLITSCREEN_ADDUSER];
+	optional int32 slot = 2;
+	optional int32 player_index = 3;
+}
+
+message CSVCMsg_GetCvarValue {
+	optional int32 cookie = 1;
 	optional string cvar_name = 2;
 }
 
-message CSVCMsg_Menu
-{
-	optional int32 dialog_type = 1;		// DIALOG_TYPE
-	optional bytes menu_key_values = 2; // KeyValues.WriteAsBinary()
+message CSVCMsg_Menu {
+	optional int32 dialog_type = 1;
+	optional bytes menu_key_values = 2;
 }
 
-message CSVCMsg_UserMessage
-{
+message CSVCMsg_UserMessage {
 	optional int32 msg_type = 1;
-	optional bytes msg_data = 2;	
+	optional bytes msg_data = 2;
+	optional int32 passthrough = 3;
 }
 
-message CSVCMsg_GameEvent
-{
-	message key_t
-	{
-		optional int32 type = 1;			// type
-		optional string val_string = 2;		// TYPE_STRING
-		optional float val_float = 3;		// TYPE_FLOAT 
-		optional int32 val_long = 4;		// TYPE_LONG  
-		optional int32 val_short = 5;		// TYPE_SHORT 
-		optional int32 val_byte = 6;		// TYPE_BYTE  
-		optional bool val_bool = 7;			// TYPE_BOOL  
-		optional uint64 val_uint64 = 8;		// TYPE_UINT64
-		optional bytes val_wstring = 9;		// TYPE_WSTRING
+message CSVCMsg_PaintmapData {
+	optional bytes paintmap = 1;
+}
+
+message CSVCMsg_GameEvent {
+	message key_t {
+		optional int32 type = 1;
+		optional string val_string = 2;
+		optional float val_float = 3;
+		optional int32 val_long = 4;
+		optional int32 val_short = 5;
+		optional int32 val_byte = 6;
+		optional bool val_bool = 7;
+		optional uint64 val_uint64 = 8;
+		optional bytes val_wstring = 9;
 	}
 
 	optional string event_name = 1;
 	optional int32 eventid = 2;
-	repeated key_t keys = 3;
+	repeated .CSVCMsg_GameEvent.key_t keys = 3;
+	optional int32 passthrough = 4;
 }
 
-message CSVCMsg_GameEventList
-{
-	message key_t
-	{
+message CSVCMsg_GameEventList {
+	message key_t {
 		optional int32 type = 1;
 		optional string name = 2;
-	};
+	}
 
-	message descriptor_t
-	{
+	message descriptor_t {
 		optional int32 eventid = 1;
 		optional string name = 2;
-		repeated key_t keys = 3;
-	};
+		repeated .CSVCMsg_GameEventList.key_t keys = 3;
+	}
 
-	repeated descriptor_t descriptors = 1;
+	repeated .CSVCMsg_GameEventList.descriptor_t descriptors = 1;
 }
 
-message CSVCMsg_TempEntities
-{
+message CSVCMsg_TempEntities {
 	optional bool reliable = 1;
 	optional int32 num_entries = 2;
 	optional bytes entity_data = 3;
 }
 
-message CSVCMsg_PacketEntities
-{
+message CSVCMsg_PacketEntities {
 	optional int32 max_entries = 1;
 	optional int32 updated_entries = 2;
-	optional bool is_delta = 3;	
+	optional bool is_delta = 3;
 	optional bool update_baseline = 4;
 	optional int32 baseline = 5;
 	optional int32 delta_from = 6;
 	optional bytes entity_data = 7;
 }
 
-message CSVCMsg_Sounds
-{
-	message sounddata_t
-	{
-		optional sint32			origin_x = 1;
-		optional sint32			origin_y = 2;
-		optional sint32			origin_z = 3;
-		optional uint32			volume = 4;
-		optional float			delay_value = 5;
-		optional int32			sequence_number = 6;
-		optional int32			entity_index = 7;
-		optional int32			channel = 8;
-		optional int32			pitch = 9;
-		optional int32			flags = 10;
-		optional uint32 		sound_num = 11;
-		optional fixed32		sound_num_handle = 12;
-		optional int32			speaker_entity = 13;
-		optional int32			random_seed = 14;
-		optional int32			sound_level = 15; // soundlevel_t
-		optional bool			is_sentence = 16;
-		optional bool			is_ambient = 17;
-	};
+message CSVCMsg_Sounds {
+	message sounddata_t {
+		optional sint32 origin_x = 1;
+		optional sint32 origin_y = 2;
+		optional sint32 origin_z = 3;
+		optional uint32 volume = 4;
+		optional float delay_value = 5;
+		optional int32 sequence_number = 6;
+		optional int32 entity_index = 7;
+		optional int32 channel = 8;
+		optional int32 pitch = 9;
+		optional int32 flags = 10;
+		optional uint32 sound_num = 11;
+		optional fixed32 sound_num_handle = 12;
+		optional int32 speaker_entity = 13;
+		optional int32 random_seed = 14;
+		optional int32 sound_level = 15;
+		optional bool is_sentence = 16;
+		optional bool is_ambient = 17;
+	}
 
 	optional bool reliable_sound = 1;
-	repeated sounddata_t sounds = 2;
+	repeated .CSVCMsg_Sounds.sounddata_t sounds = 2;
+}
+
+message CSVCMsg_EntityMsg {
+	optional int32 ent_index = 1;
+	optional int32 class_id = 2;
+	optional bytes ent_data = 3;
+}
+
+message CSVCMsg_CmdKeyValues {
+	optional bytes keyvalues = 1;
+}
+
+message CSVCMsg_EncryptedData {
+	optional bytes encrypted = 1;
+	optional int32 key_type = 2;
+}
+
+message CSVCMsg_HltvReplay {
+	optional int32 delay = 1;
+	optional int32 primary_target = 2;
+	optional int32 replay_stop_at = 3;
+	optional int32 replay_start_at = 4;
+	optional int32 replay_slowdown_begin = 5;
+	optional int32 replay_slowdown_end = 6;
+	optional float replay_slowdown_rate = 7;
+}
+
+message CCLCMsg_HltvReplay {
+	optional int32 request = 1;
+	optional float slowdown_length = 2;
+	optional float slowdown_rate = 3;
+	optional int32 primary_target_ent_index = 4;
+	optional float event_time = 5;
 }

--- a/src/steammessages.proto
+++ b/src/steammessages.proto
@@ -1,0 +1,524 @@
+import "google/protobuf/descriptor.proto";
+
+option optimize_for = SPEED;
+option cc_generic_services = false;
+
+extend .google.protobuf.FieldOptions {
+	optional bool key_field = 60000 [default = false];
+}
+
+extend .google.protobuf.MessageOptions {
+	optional int32 msgpool_soft_limit = 60000 [default = 32];
+	optional int32 msgpool_hard_limit = 60001 [default = 384];
+}
+
+enum GCProtoBufMsgSrc {
+	GCProtoBufMsgSrc_Unspecified = 0;
+	GCProtoBufMsgSrc_FromSystem = 1;
+	GCProtoBufMsgSrc_FromSteamID = 2;
+	GCProtoBufMsgSrc_FromGC = 3;
+	GCProtoBufMsgSrc_ReplySystem = 4;
+}
+
+message CMsgProtoBufHeader {
+	option (msgpool_soft_limit) = 256;
+	option (msgpool_hard_limit) = 1024;
+	optional fixed64 client_steam_id = 1;
+	optional int32 client_session_id = 2;
+	optional uint32 source_app_id = 3;
+	optional fixed64 job_id_source = 10 [default = 18446744073709551615];
+	optional fixed64 job_id_target = 11 [default = 18446744073709551615];
+	optional string target_job_name = 12;
+	optional int32 eresult = 13 [default = 2];
+	optional string error_message = 14;
+	optional .GCProtoBufMsgSrc gc_msg_src = 200 [default = GCProtoBufMsgSrc_Unspecified];
+	optional uint32 gc_dir_index_source = 201;
+}
+
+message CMsgWebAPIKey {
+	optional uint32 status = 1 [default = 255];
+	optional uint32 account_id = 2 [default = 0];
+	optional uint32 publisher_group_id = 3 [default = 0];
+	optional uint32 key_id = 4;
+	optional string domain = 5;
+}
+
+message CMsgHttpRequest {
+	message RequestHeader {
+		optional string name = 1;
+		optional string value = 2;
+	}
+
+	message QueryParam {
+		optional string name = 1;
+		optional bytes value = 2;
+	}
+
+	optional uint32 request_method = 1;
+	optional string hostname = 2;
+	optional string url = 3;
+	repeated .CMsgHttpRequest.RequestHeader headers = 4;
+	repeated .CMsgHttpRequest.QueryParam get_params = 5;
+	repeated .CMsgHttpRequest.QueryParam post_params = 6;
+	optional bytes body = 7;
+	optional uint32 absolute_timeout = 8;
+}
+
+message CMsgWebAPIRequest {
+	optional string UNUSED_job_name = 1;
+	optional string interface_name = 2;
+	optional string method_name = 3;
+	optional uint32 version = 4;
+	optional .CMsgWebAPIKey api_key = 5;
+	optional .CMsgHttpRequest request = 6;
+	optional uint32 routing_app_id = 7;
+}
+
+message CMsgHttpResponse {
+	message ResponseHeader {
+		optional string name = 1;
+		optional string value = 2;
+	}
+
+	optional uint32 status_code = 1;
+	repeated .CMsgHttpResponse.ResponseHeader headers = 2;
+	optional bytes body = 3;
+}
+
+message CMsgAMFindAccounts {
+	optional uint32 search_type = 1;
+	optional string search_string = 2;
+}
+
+message CMsgAMFindAccountsResponse {
+	repeated fixed64 steam_id = 1;
+}
+
+message CMsgNotifyWatchdog {
+	optional uint32 source = 1;
+	optional uint32 alert_type = 2;
+	optional uint32 alert_destination = 3;
+	optional bool critical = 4;
+	optional uint32 time = 5;
+	optional uint32 appid = 6;
+	optional string text = 7;
+}
+
+message CMsgAMGetLicenses {
+	optional fixed64 steamid = 1;
+}
+
+message CMsgPackageLicense {
+	optional uint32 package_id = 1;
+	optional uint32 time_created = 2;
+	optional uint32 owner_id = 3;
+}
+
+message CMsgAMGetLicensesResponse {
+	repeated .CMsgPackageLicense license = 1;
+	optional uint32 result = 2;
+}
+
+message CMsgAMGetUserGameStats {
+	optional fixed64 steam_id = 1;
+	optional fixed64 game_id = 2;
+	repeated uint32 stats = 3;
+}
+
+message CMsgAMGetUserGameStatsResponse {
+	message Stats {
+		optional uint32 stat_id = 1;
+		optional uint32 stat_value = 2;
+	}
+
+	message Achievement_Blocks {
+		optional uint32 achievement_id = 1;
+		optional uint32 achievement_bit_id = 2;
+		optional fixed32 unlock_time = 3;
+	}
+
+	optional fixed64 steam_id = 1;
+	optional fixed64 game_id = 2;
+	optional int32 eresult = 3 [default = 2];
+	repeated .CMsgAMGetUserGameStatsResponse.Stats stats = 4;
+	repeated .CMsgAMGetUserGameStatsResponse.Achievement_Blocks achievement_blocks = 5;
+}
+
+message CMsgGCGetCommandList {
+	optional uint32 app_id = 1;
+	optional string command_prefix = 2;
+}
+
+message CMsgGCGetCommandListResponse {
+	repeated string command_name = 1;
+}
+
+message CGCMsgMemCachedGet {
+	repeated string keys = 1;
+}
+
+message CGCMsgMemCachedGetResponse {
+	message ValueTag {
+		optional bool found = 1;
+		optional bytes value = 2;
+	}
+
+	repeated .CGCMsgMemCachedGetResponse.ValueTag values = 1;
+}
+
+message CGCMsgMemCachedSet {
+	message KeyPair {
+		optional string name = 1;
+		optional bytes value = 2;
+	}
+
+	repeated .CGCMsgMemCachedSet.KeyPair keys = 1;
+}
+
+message CGCMsgMemCachedDelete {
+	repeated string keys = 1;
+}
+
+message CGCMsgMemCachedStats {
+}
+
+message CGCMsgMemCachedStatsResponse {
+	optional uint64 curr_connections = 1;
+	optional uint64 cmd_get = 2;
+	optional uint64 cmd_set = 3;
+	optional uint64 cmd_flush = 4;
+	optional uint64 get_hits = 5;
+	optional uint64 get_misses = 6;
+	optional uint64 delete_hits = 7;
+	optional uint64 delete_misses = 8;
+	optional uint64 bytes_read = 9;
+	optional uint64 bytes_written = 10;
+	optional uint64 limit_maxbytes = 11;
+	optional uint64 curr_items = 12;
+	optional uint64 evictions = 13;
+	optional uint64 bytes = 14;
+}
+
+message CGCMsgSQLStats {
+	optional uint32 schema_catalog = 1;
+}
+
+message CGCMsgSQLStatsResponse {
+	optional uint32 threads = 1;
+	optional uint32 threads_connected = 2;
+	optional uint32 threads_active = 3;
+	optional uint32 operations_submitted = 4;
+	optional uint32 prepared_statements_executed = 5;
+	optional uint32 non_prepared_statements_executed = 6;
+	optional uint32 deadlock_retries = 7;
+	optional uint32 operations_timed_out_in_queue = 8;
+	optional uint32 errors = 9;
+}
+
+message CMsgAMAddFreeLicense {
+	optional fixed64 steamid = 1;
+	optional uint32 ip_public = 2;
+	optional uint32 packageid = 3;
+	optional string store_country_code = 4;
+}
+
+message CMsgAMAddFreeLicenseResponse {
+	optional int32 eresult = 1 [default = 2];
+	optional int32 purchase_result_detail = 2;
+	optional fixed64 transid = 3;
+}
+
+message CGCMsgGetIPLocation {
+	repeated fixed32 ips = 1;
+}
+
+message CIPLocationInfo {
+	optional uint32 ip = 1;
+	optional float latitude = 2;
+	optional float longitude = 3;
+	optional string country = 4;
+	optional string state = 5;
+	optional string city = 6;
+}
+
+message CGCMsgGetIPLocationResponse {
+	repeated .CIPLocationInfo infos = 1;
+}
+
+message CGCMsgSystemStatsSchema {
+	optional uint32 gc_app_id = 1;
+	optional bytes schema_kv = 2;
+}
+
+message CGCMsgGetSystemStats {
+}
+
+message CGCMsgGetSystemStatsResponse {
+	optional uint32 gc_app_id = 1;
+	optional bytes stats_kv = 2;
+	optional uint32 active_jobs = 3;
+	optional uint32 yielding_jobs = 4;
+	optional uint32 user_sessions = 5;
+	optional uint32 game_server_sessions = 6;
+	optional uint32 socaches = 7;
+	optional uint32 socaches_to_unload = 8;
+	optional uint32 socaches_loading = 9;
+	optional uint32 writeback_queue = 10;
+	optional uint32 steamid_locks = 11;
+	optional uint32 logon_queue = 12;
+	optional uint32 logon_jobs = 13;
+}
+
+message CMsgAMSendEmail {
+	message ReplacementToken {
+		optional string token_name = 1;
+		optional string token_value = 2;
+	}
+
+	message PersonaNameReplacementToken {
+		optional fixed64 steamid = 1;
+		optional string token_name = 2;
+	}
+
+	optional fixed64 steamid = 1;
+	optional uint32 email_msg_type = 2;
+	optional uint32 email_format = 3;
+	repeated .CMsgAMSendEmail.PersonaNameReplacementToken persona_name_tokens = 5;
+	optional uint32 source_gc = 6;
+	repeated .CMsgAMSendEmail.ReplacementToken tokens = 7;
+}
+
+message CMsgAMSendEmailResponse {
+	optional uint32 eresult = 1 [default = 2];
+}
+
+message CMsgGCGetEmailTemplate {
+	optional uint32 app_id = 1;
+	optional uint32 email_msg_type = 2;
+	optional int32 email_lang = 3;
+	optional int32 email_format = 4;
+}
+
+message CMsgGCGetEmailTemplateResponse {
+	optional uint32 eresult = 1 [default = 2];
+	optional bool template_exists = 2;
+	optional string template = 3;
+}
+
+message CMsgAMGrantGuestPasses2 {
+	optional fixed64 steam_id = 1;
+	optional uint32 package_id = 2;
+	optional int32 passes_to_grant = 3;
+	optional int32 days_to_expiration = 4;
+	optional int32 action = 5;
+}
+
+message CMsgAMGrantGuestPasses2Response {
+	optional int32 eresult = 1 [default = 2];
+	optional int32 passes_granted = 2 [default = 0];
+}
+
+message CGCSystemMsg_GetAccountDetails {
+	option (msgpool_soft_limit) = 128;
+	option (msgpool_hard_limit) = 512;
+	optional fixed64 steamid = 1;
+	optional uint32 appid = 2;
+}
+
+message CGCSystemMsg_GetAccountDetails_Response {
+	option (msgpool_soft_limit) = 128;
+	option (msgpool_hard_limit) = 512;
+	optional uint32 eresult_deprecated = 1 [default = 2];
+	optional string account_name = 2;
+	optional string persona_name = 3;
+	optional bool is_profile_public = 4;
+	optional bool is_inventory_public = 5;
+	optional bool is_vac_banned = 7;
+	optional bool is_cyber_cafe = 8;
+	optional bool is_school_account = 9;
+	optional bool is_limited = 10;
+	optional bool is_subscribed = 11;
+	optional uint32 package = 12;
+	optional bool is_free_trial_account = 13;
+	optional uint32 free_trial_expiration = 14;
+	optional bool is_low_violence = 15;
+	optional bool is_account_locked_down = 16;
+	optional bool is_community_banned = 17;
+	optional bool is_trade_banned = 18;
+	optional uint32 trade_ban_expiration = 19;
+	optional uint32 accountid = 20;
+	optional uint32 suspension_end_time = 21;
+	optional string currency = 22;
+	optional uint32 steam_level = 23;
+	optional uint32 friend_count = 24;
+	optional uint32 account_creation_time = 25;
+	optional bool is_steamguard_enabled = 27;
+	optional bool is_phone_verified = 28;
+	optional bool is_two_factor_auth_enabled = 29;
+	optional uint32 two_factor_enabled_time = 30;
+	optional uint32 phone_verification_time = 31;
+	optional uint64 phone_id = 33;
+	optional bool is_phone_identifying = 34;
+}
+
+message CMsgGCGetPersonaNames {
+	repeated fixed64 steamids = 1;
+}
+
+message CMsgGCGetPersonaNames_Response {
+	message PersonaName {
+		optional fixed64 steamid = 1;
+		optional string persona_name = 2;
+	}
+
+	repeated .CMsgGCGetPersonaNames_Response.PersonaName succeeded_lookups = 1;
+	repeated fixed64 failed_lookup_steamids = 2;
+}
+
+message CMsgGCCheckFriendship {
+	optional fixed64 steamid_left = 1;
+	optional fixed64 steamid_right = 2;
+}
+
+message CMsgGCCheckFriendship_Response {
+	optional bool success = 1;
+	optional bool found_friendship = 2;
+}
+
+message CMsgGCMsgMasterSetDirectory {
+	message SubGC {
+		optional uint32 dir_index = 1;
+		optional string name = 2;
+		optional string box = 3;
+		optional string command_line = 4;
+		optional string gc_binary = 5;
+	}
+
+	optional uint32 master_dir_index = 1;
+	repeated .CMsgGCMsgMasterSetDirectory.SubGC dir = 2;
+}
+
+message CMsgGCMsgMasterSetDirectory_Response {
+	optional int32 eresult = 1 [default = 2];
+}
+
+message CMsgGCMsgWebAPIJobRequestForwardResponse {
+	optional uint32 dir_index = 1;
+}
+
+message CGCSystemMsg_GetPurchaseTrust_Request {
+	optional fixed64 steamid = 1;
+}
+
+message CGCSystemMsg_GetPurchaseTrust_Response {
+	optional bool has_prior_purchase_history = 1;
+	optional bool has_no_recent_password_resets = 2;
+	optional bool is_wallet_cash_trusted = 3;
+	optional uint32 time_all_trusted = 4;
+}
+
+message CMsgGCHAccountVacStatusChange {
+	optional fixed64 steam_id = 1;
+	optional uint32 app_id = 2;
+	optional uint32 rtime_vacban_starts = 3;
+	optional bool is_banned_now = 4;
+	optional bool is_banned_future = 5;
+}
+
+message CMsgGCGetPartnerAccountLink {
+	optional fixed64 steamid = 1;
+}
+
+message CMsgGCGetPartnerAccountLink_Response {
+	optional uint32 pwid = 1;
+	optional uint32 nexonid = 2;
+}
+
+message CMsgGCRoutingInfo {
+	enum RoutingMethod {
+		RANDOM = 0;
+		DISCARD = 1;
+		CLIENT_STEAMID = 2;
+		PROTOBUF_FIELD_UINT64 = 3;
+		WEBAPI_PARAM_UINT64 = 4;
+	}
+
+	repeated uint32 dir_index = 1;
+	optional .CMsgGCRoutingInfo.RoutingMethod method = 2 [default = RANDOM];
+	optional .CMsgGCRoutingInfo.RoutingMethod fallback = 3 [default = DISCARD];
+	optional uint32 protobuf_field = 4;
+	optional string webapi_param = 5;
+}
+
+message CMsgGCMsgMasterSetWebAPIRouting {
+	message Entry {
+		optional string interface_name = 1;
+		optional string method_name = 2;
+		optional .CMsgGCRoutingInfo routing = 3;
+	}
+
+	repeated .CMsgGCMsgMasterSetWebAPIRouting.Entry entries = 1;
+}
+
+message CMsgGCMsgMasterSetClientMsgRouting {
+	message Entry {
+		optional uint32 msg_type = 1;
+		optional .CMsgGCRoutingInfo routing = 2;
+	}
+
+	repeated .CMsgGCMsgMasterSetClientMsgRouting.Entry entries = 1;
+}
+
+message CMsgGCMsgMasterSetWebAPIRouting_Response {
+	optional int32 eresult = 1 [default = 2];
+}
+
+message CMsgGCMsgMasterSetClientMsgRouting_Response {
+	optional int32 eresult = 1 [default = 2];
+}
+
+message CMsgGCMsgSetOptions {
+	message MessageRange {
+		required uint32 low = 1;
+		required uint32 high = 2;
+	}
+
+	enum Option {
+		NOTIFY_USER_SESSIONS = 0;
+		NOTIFY_SERVER_SESSIONS = 1;
+		NOTIFY_ACHIEVEMENTS = 2;
+		NOTIFY_VAC_ACTION = 3;
+	}
+
+	repeated .CMsgGCMsgSetOptions.Option options = 1;
+	repeated .CMsgGCMsgSetOptions.MessageRange client_msg_ranges = 2;
+}
+
+message CMsgGCHUpdateSession {
+	message ExtraField {
+		optional string name = 1;
+		optional string value = 2;
+	}
+
+	optional fixed64 steam_id = 1;
+	optional uint32 app_id = 2;
+	optional bool online = 3;
+	optional fixed64 server_steam_id = 4;
+	optional uint32 server_addr = 5;
+	optional uint32 server_port = 6;
+	optional uint32 os_type = 7;
+	optional uint32 client_addr = 8;
+	repeated .CMsgGCHUpdateSession.ExtraField extra_fields = 9;
+}
+
+message CMsgNotificationOfSuspiciousActivity {
+	message MultipleGameInstances {
+		optional uint32 app_instance_count = 1;
+		repeated fixed64 other_steamids = 2;
+	}
+
+	optional fixed64 steamid = 1;
+	optional uint32 appid = 2;
+	optional .CMsgNotificationOfSuspiciousActivity.MultipleGameInstances multiple_instances = 3;
+}
+


### PR DESCRIPTION
I've added updated protobuf's from:
https://github.com/SteamRE/SteamKit/blob/master/Resources/Protobufs/csgo/cstrike15_usermessages.proto

Mainly because it includes CS_UM_ServerRankRevealAll which is at the end of the demo giving all player ranks. Seems a few of the demo parsing projects already have this, so felt it was needed here.

My first pull request! Hope it's OK!